### PR TITLE
Update dependencies, rename package, add missing Bbox functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 ## [Unreleased]
 
 ### Added
+- Added ability to transform `Bbox` to `Extent` [\#5](https://github.com/azavea/stac4s/pull/5)
 
 ### Changed
+- Updated to GeoTrellis 3.2 [\#5](https://github.com/azavea/stac4s/pull/5)
 
 ### Deprecated
 
 ### Removed
+- Removed `core` from package naming [\#5](https://github.com/azavea/stac4s/pull/5)
 
 ### Fixed
 

--- a/build.sbt
+++ b/build.sbt
@@ -114,7 +114,7 @@ val coreDependencies = Seq(
   "org.scalatest"               %% "scalatest"           % Versions.scalatestVersion % Test,
   "com.github.tbouron"          % "spdx-license-checker" % Versions.spdxCheckerVersion,
   "com.chuusai"                 %% "shapeless"           % Versions.ShapelessVersion,
-  "io.spray"                    %% "spray-json"          % Versions.sprayVersion
+  "org.locationtech.jts"        % "jts-core"             % Versions.jts
 )
 
 lazy val root = project

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
@@ -5,6 +5,7 @@ import geotrellis.vector.Extent
 import io.circe._
 import io.circe.syntax._
 
+@SuppressWarnings(Array("CatchThrowable"))
 sealed trait Bbox {
   val xmin: Double
   val ymin: Double

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
@@ -1,11 +1,22 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
+import geotrellis.vector.Extent
 import io.circe._
 import io.circe.syntax._
 
 sealed trait Bbox {
+  val xmin: Double
+  val ymin: Double
+  val xmax: Double
+  val ymax: Double
   val toList: List[Double]
+
+  val toExtent: Either[Throwable, Extent] = try {
+    Either.right(Extent(xmin, ymin, xmax, ymax))
+  } catch {
+    case e: Throwable => Either.left(e)
+  }
 }
 
 final case class TwoDimBbox(xmin: Double, ymin: Double, xmax: Double, ymax: Double) extends Bbox {

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/Bbox.scala
@@ -1,11 +1,10 @@
 package com.azavea.stac4s
 
 import cats.implicits._
-import geotrellis.vector.Extent
+import geotrellis.vector.{Extent, ExtentRangeError}
 import io.circe._
 import io.circe.syntax._
 
-@SuppressWarnings(Array("CatchThrowable"))
 sealed trait Bbox {
   val xmin: Double
   val ymin: Double
@@ -13,10 +12,10 @@ sealed trait Bbox {
   val ymax: Double
   val toList: List[Double]
 
-  val toExtent: Either[Throwable, Extent] = try {
+  val toExtent: Either[String, Extent] = try {
     Either.right(Extent(xmin, ymin, xmax, ymax))
   } catch {
-    case e: Throwable => Either.left(e)
+    case e: ExtentRangeError => Either.left(e.toString)
   }
 }
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/ItemCollection.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/ItemCollection.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import io.circe._
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacAsset.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacAsset.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import io.circe._
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacCatalog.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacCatalog.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import io.circe._
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacCollection.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacCollection.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import geotrellis.vector.{io => _}
 import io.circe._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacExtent.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacExtent.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import com.azavea.stac4s.meta._
 import io.circe._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacItem.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacItem.scala
@@ -1,7 +1,7 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import com.azavea.stac4s.meta._
-import geotrellis.vector.{io => _, _}
+import geotrellis.vector.Geometry
 import io.circe._
 
 final case class StacItem(

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacLicense.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacLicense.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import eu.timepit.refined.api.RefType

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacLink.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacLink.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import io.circe._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacLinkType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacLinkType.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import io.circe._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacMediaType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacMediaType.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import io.circe._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacProvider.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacProvider.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import io.circe._
 import io.circe.generic.semiauto._

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/StacProviderRole.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/StacProviderRole.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import io.circe._
@@ -18,6 +18,7 @@ object StacProviderRole {
 
   implicit val encProviderRole: Encoder[StacProviderRole] =
     Encoder.encodeString.contramap[StacProviderRole](_.toString)
+
   implicit val decProviderRole: Decoder[StacProviderRole] =
     Decoder.decodeString.emap { str =>
       Either.catchNonFatal(fromString(str)).leftMap(_ => "StacProviderRole")

--- a/modules/core/src/main/scala/com/azavea/stac4s/core/package.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/core/package.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s
+package com.azavea
 
 import java.time.Instant
 
@@ -9,7 +9,7 @@ import eu.timepit.refined.boolean._
 import eu.timepit.refined.collection.{Exists, MinSize, _}
 import geotrellis.vector.{io => _}
 
-package object core {
+package object stac4s {
 
   type SpdxId = String Refined ValidSpdxId
   object SpdxId extends RefinedTypeOps[SpdxId, String]

--- a/modules/core/src/main/scala/com/azavea/stac4s/meta/package.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/meta/package.scala
@@ -3,14 +3,13 @@ package com.azavea.stac4s
 import java.time.Instant
 
 import cats.implicits._
-import com.azavea.stac4s.core.TemporalExtent
 import eu.timepit.refined.api.RefType
-import geotrellis.vector.{io => _, _}
+import geotrellis.vector.io.json.GeometryFormats
 import io.circe._
-import io.circe.parser.{decode, parse}
+import io.circe.parser.decode
 import io.circe.syntax._
 
-package object meta {
+package object meta extends GeometryFormats {
 
   // Stolen straight from circe docs
   implicit val decodeInstant: Decoder[Instant] = Decoder.decodeString.emap { str =>
@@ -35,20 +34,6 @@ package object meta {
       case l =>
         RefType.applyRef[TemporalExtent](l)
     }
-
-  implicit val geometryDecoder: Decoder[Geometry] = Decoder[Json] map { js =>
-    js.spaces4.parseGeoJson[Geometry]
-  }
-
-  implicit val geometryEncoder: Encoder[Geometry] = new Encoder[Geometry] {
-
-    def apply(geom: Geometry) = {
-      parse(geom.toGeoJson) match {
-        case Right(js) => js
-        case Left(e)   => throw e
-      }
-    }
-  }
 
   implicit val decTimeRange: Decoder[(Option[Instant], Option[Instant])] = Decoder[String] map { str =>
     val components = str.replace("[", "").replace("]", "").split(",") map {

--- a/modules/core/src/test/scala/com/azavea/stac4s/core/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/core/Generators.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import cats.implicits._
 import geotrellis.vector.{Geometry, Point, Polygon}

--- a/modules/core/src/test/scala/com/azavea/stac4s/core/SerDeSpec.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/core/SerDeSpec.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.core
+package com.azavea.stac4s
 
 import com.azavea.stac4s.meta._
 import Generators._
@@ -12,9 +12,7 @@ import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
 import java.time.Instant
 
-import com.typesafe.scalalogging.LazyLogging
-
-class SerDeSpec extends FunSpec with Matchers with PropertyChecks with LazyLogging {
+class SerDeSpec extends FunSpec with Matchers with PropertyChecks {
 
   private def getPropTest[T: Arbitrary: Encoder: Decoder] = forAll { (x: T) =>
     {

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,8 +1,8 @@
 object Versions {
-  val CatsVersion           = "1.6.0"
-  val CirceVersion          = "0.11.1"
-  val GeoTrellisVersion     = "3.0.0-M3"
-  val RefinedVersion        = "0.9.3"
+  val CatsVersion           = "2.0.0"
+  val CirceVersion          = "0.12.2"
+  val GeoTrellisVersion     = "3.2.0"
+  val RefinedVersion        = "0.9.10"
   val ScapegoatVersion      = "1.3.8"
   val ShapelessVersion      = "2.3.3"
   val spdxCheckerVersion    = "1.0.0"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,6 +8,6 @@ object Versions {
   val spdxCheckerVersion    = "1.0.0"
   val scalacheckCatsVersion = "0.1.1"
   val scalatestVersion      = "3.0.4"
-  val sprayVersion          = "1.3.4"
   val scalacheckVersion     = "1.14.0"
+  val jts                   = "1.16.1"
 }


### PR DESCRIPTION
## Overview

Updates to latest GeoTrellis - 3.2 and includes updated Cats dependencies.

Also renames packages to remove `core` from the name to make it less onerous to use.

Lastly, adds `toExtent` method to `Bbox` to streamline `extent` <-> `bbox` conversion

### Checklist

~- [ ] New tests have been added or existing tests have been modified~

### Notes

I think this should signal the next release as `0.0.3` so that we can test using this when we upgrade Franklin and `Raster Foundry`