### PR TITLE
Fix sonatype publication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
               only:
                 - /^(.*)$/
             branches:
-              ignore:
+              only:
                 - /^(.*)$/
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
               only:
                 - /^(.*)$/
             branches:
-              only:
+              ignore:
                 - /^(.*)$/
 
 jobs:

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -19,7 +19,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     else
         echo "Publishing artifacts to Sonatype"
         if [[ -n "${CIRCLE_TAG}" ]]; then
-            ./sbt ";sonatypeOpen ${CIRCLE_BUILD_NUM};publish;sonatypeRelease"
+            ./sbt ";sonatypeOpen;publish;sonatypeRelease"
         else
             ./sbt publish
         fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -19,8 +19,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     else
         echo "Publishing artifacts to Sonatype"
         if [[ -n "${CIRCLE_TAG}" ]]; then
+	    echo "Building with ${CIRCLE_TAG}"
             ./sbt ";sonatypeOpen;publish;sonatypeRelease"
         else
+	    echo "Building untagged"
             ./sbt publish
         fi
     fi


### PR DESCRIPTION
## Overview

This PR changes the `sonatypeOpen` command no longer to have an argument, since it seems like it doesn't expect one.

### Checklist

- ~New tests have been added or existing tests have been modified~

## Testing

- it works! https://app.circleci.com/pipelines/github/azavea/stac4s/154/workflows/67160d33-19b2-469b-9c97-11b75fa8f697/jobs/181/steps
- proof: add the `0.0.7-bugfix2` dependency to one of your scala projects and check where it gets resolved from

Closes #53 
