### PR TITLE
Only gen finite doubles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Stopped generating `NaN`s as valid `Double` values [#91](https://github.com/azavea/stac4s/pull/91)
+
 ### Security
 
 ## [0.0.4]

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -126,8 +126,11 @@ object Generators {
     Host
   )
 
+  private def finiteDoubleGen: Gen[Double] =
+    arbitrary[Double].filter((n: Double) => !n.isNaN)
+
   private def twoDimBboxGen: Gen[TwoDimBbox] =
-    (arbitrary[Double], arbitrary[Double], arbitrary[Double], arbitrary[Double])
+    (finiteDoubleGen, finiteDoubleGen, finiteDoubleGen, finiteDoubleGen)
       .mapN(TwoDimBbox.apply)
 
   private def spdxGen: Gen[SPDX] =
@@ -139,12 +142,12 @@ object Generators {
 
   private def threeDimBboxGen: Gen[ThreeDimBbox] =
     (
-      arbitrary[Double],
-      arbitrary[Double],
-      arbitrary[Double],
-      arbitrary[Double],
-      arbitrary[Double],
-      arbitrary[Double]
+      finiteDoubleGen,
+      finiteDoubleGen,
+      finiteDoubleGen,
+      finiteDoubleGen,
+      finiteDoubleGen,
+      finiteDoubleGen
     ).mapN(ThreeDimBbox.apply)
 
   private def bboxGen: Gen[Bbox] =
@@ -293,7 +296,7 @@ object Generators {
   private def labelStatsGen: Gen[LabelStats] =
     (
       nonEmptyStringGen,
-      arbitrary[Double]
+      finiteDoubleGen
     ).mapN(LabelStats.apply)
 
   private def labelOverviewWithCounts: Gen[LabelOverview] =


### PR DESCRIPTION
## Overview

This PR makes it so that bboxes and other classes requiring doubles are guaranteed finite doubles. It prevents flaky test results where `NaN != NaN` was causing equality expectations to fail.

### Checklist

- [x] New tests have been added or existing tests have been modified
- [ ] Changelog updated