### PR TITLE
Parse EO extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Created typeclasses for linking extensions to the items they extend [#85](https://github.com/azavea/stac4s/pull/85)
+- Created extension data model for EO Extension [#92](https://github.com/azavea/stac4s/pull/92)
 
 ### Changed
 

--- a/build.sbt
+++ b/build.sbt
@@ -112,6 +112,7 @@ val coreDependencies = Seq(
   "io.circe"                    %% "circe-testing"       % Versions.CirceVersion % "test",
   "org.locationtech.geotrellis" %% "geotrellis-vector"   % Versions.GeoTrellisVersion,
   "eu.timepit"                  %% "refined"             % Versions.RefinedVersion,
+  "eu.timepit"                  %% "refined-scalacheck"  % Versions.RefinedVersion % "test",
   "org.scalacheck"              %% "scalacheck"          % Versions.scalacheckVersion % Test,
   "io.chrisdavenport"           %% "cats-scalacheck"     % Versions.scalacheckCatsVersion % Test,
   "org.scalatest"               %% "scalatest"           % Versions.scalatestVersion % Test,

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
@@ -1,5 +1,6 @@
 package com.azavea.stac4s.extensions.eo
 
+import cats.Eq
 import eu.timepit.refined.types.string.NonEmptyString
 import io.circe._
 import io.circe.refined._
@@ -13,6 +14,8 @@ case class Band(
 )
 
 object Band {
+
+  implicit val eqBand: Eq[Band] = Eq.fromUniversalEquals
 
   implicit val encBand: Encoder[Band] = Encoder.forProduct5(
     "name",

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
@@ -1,0 +1,32 @@
+package com.azavea.stac4s.extensions.eo
+
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe._
+import io.circe.refined._
+
+case class Band(
+    name: NonEmptyString,
+    commonName: NonEmptyString,
+    description: NonEmptyString,
+    centerWavelength: Int,
+    fullWidthHalfMax: Int
+)
+
+object Band {
+
+  implicit val encBand: Encoder[Band] = Encoder.forProduct5(
+    "name",
+    "common_name",
+    "description",
+    "center_wavelength",
+    "full_width_half_max"
+  )(band => (band.name, band.commonName, band.description, band.centerWavelength, band.fullWidthHalfMax))
+
+  implicit val decBand: Decoder[Band] = Decoder.forProduct5(
+    "name",
+    "common_name",
+    "description",
+    "center_wavelength",
+    "full_width_half_max"
+  )(Band.apply)
+}

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
@@ -2,15 +2,16 @@ package com.azavea.stac4s.extensions.eo
 
 import cats.Eq
 import eu.timepit.refined.types.string.NonEmptyString
+import eu.timepit.refined.types.numeric.PosInt
 import io.circe._
 import io.circe.refined._
 
 case class Band(
     name: NonEmptyString,
-    commonName: NonEmptyString,
-    description: NonEmptyString,
-    centerWavelength: Int,
-    fullWidthHalfMax: Int
+    commonName: Option[NonEmptyString],
+    description: Option[NonEmptyString],
+    centerWavelength: Option[PosInt],
+    fullWidthHalfMax: Option[PosInt]
 )
 
 object Band {

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOAssetExtension.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOAssetExtension.scala
@@ -1,0 +1,21 @@
+package com.azavea.stac4s.extensions.eo
+
+import com.azavea.stac4s.extensions.ItemAssetExtension
+
+import cats.data.NonEmptyList
+import io.circe._
+import io.circe.syntax._
+
+case class EOAssetExtension(
+    bands: NonEmptyList[Int]
+)
+
+object EOAssetExtension {
+
+  implicit val encEOAssetExtension: Encoder.AsObject[EOAssetExtension] =
+    Encoder.AsObject[Map[String, Json]].contramapObject(assetExt => Map("eo:bands" -> assetExt.asJson))
+
+  implicit val decEOAssetExtension: Decoder[EOAssetExtension] = Decoder.forProduct1("eo:bands")(EOAssetExtension.apply)
+
+  implicit val assetExtension: ItemAssetExtension[EOAssetExtension] = ItemAssetExtension.instance
+}

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOAssetExtension.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOAssetExtension.scala
@@ -2,18 +2,22 @@ package com.azavea.stac4s.extensions.eo
 
 import com.azavea.stac4s.extensions.ItemAssetExtension
 
+import cats.Eq
 import cats.data.NonEmptyList
 import io.circe._
+import io.circe.refined._
 import io.circe.syntax._
 
 case class EOAssetExtension(
-    bands: NonEmptyList[Int]
+    bands: NonEmptyList[BandRange]
 )
 
 object EOAssetExtension {
 
+  implicit val eqEOAssetExtension: Eq[EOAssetExtension] = Eq.fromUniversalEquals
+
   implicit val encEOAssetExtension: Encoder.AsObject[EOAssetExtension] =
-    Encoder.AsObject[Map[String, Json]].contramapObject(assetExt => Map("eo:bands" -> assetExt.asJson))
+    Encoder.AsObject[Map[String, Json]].contramapObject(assetExt => Map("eo:bands" -> assetExt.bands.asJson))
 
   implicit val decEOAssetExtension: Decoder[EOAssetExtension] = Decoder.forProduct1("eo:bands")(EOAssetExtension.apply)
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOItemExtension.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/EOItemExtension.scala
@@ -1,0 +1,33 @@
+package com.azavea.stac4s.extensions.eo
+
+import cats.Eq
+import cats.data.NonEmptyList
+import io.circe._
+import io.circe.refined._
+import io.circe.syntax._
+import com.azavea.stac4s.extensions.ItemExtension
+
+case class EOItemExtension(
+    gsd: Double,
+    bands: NonEmptyList[Band],
+    cloudCover: Option[Percentage]
+)
+
+object EOItemExtension {
+
+  implicit val eq: Eq[EOItemExtension] = Eq.fromUniversalEquals
+
+  implicit val encEOItemExtension: Encoder.AsObject[EOItemExtension] = Encoder
+    .AsObject[Map[String, Json]]
+    .contramapObject(band =>
+      Map("eo:gsd" -> band.gsd.asJson, "eo:bands" -> band.bands.asJson, "eo:cloud_cover" -> band.cloudCover.asJson)
+    )
+
+  implicit val decEOItemExtension: Decoder[EOItemExtension] = Decoder.forProduct3(
+    "eo:gsd",
+    "eo:bands",
+    "eo:cloud_cover"
+  )(EOItemExtension.apply)
+
+  implicit val itemExtension: ItemExtension[EOItemExtension] = ItemExtension.instance
+}

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
@@ -3,11 +3,11 @@ package com.azavea.stac4s.extensions
 import eu.timepit.refined._
 import eu.timepit.refined.api._
 import eu.timepit.refined.numeric._
+import eu.timepit.refined.types.numeric.PosInt
 
 package object eo {
   type Percentage = Int Refined Interval.Closed[W.`0`.T, W.`100`.T]
   object Percentage extends RefinedTypeOps[Percentage, Int]
 
-  type BandRange = Int Refined Interval.Closed[W.`0`.T, W.`100`.T]
-  object BandRange extends RefinedTypeOps[BandRange, Int]
+  type BandRange = PosInt
 }

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
@@ -7,4 +7,7 @@ import eu.timepit.refined.numeric._
 package object eo {
   type Percentage = Int Refined Interval.Closed[W.`0`.T, W.`100`.T]
   object Percentage extends RefinedTypeOps[Percentage, Int]
+
+  type BandRange = Int Refined Interval.Closed[W.`0`.T, W.`100`.T]
+  object BandRange extends RefinedTypeOps[BandRange, Int]
 }

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/eo/package.scala
@@ -1,0 +1,10 @@
+package com.azavea.stac4s.extensions
+
+import eu.timepit.refined._
+import eu.timepit.refined.api._
+import eu.timepit.refined.numeric._
+
+package object eo {
+  type Percentage = Int Refined Interval.Closed[W.`0`.T, W.`100`.T]
+  object Percentage extends RefinedTypeOps[Percentage, Int]
+}

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -2,9 +2,14 @@ package com.azavea.stac4s
 
 import com.azavea.stac4s.extensions.eo._
 import com.azavea.stac4s.extensions.label._
+import com.azavea.stac4s.extensions.label.LabelClassClasses._
+import com.azavea.stac4s.extensions.layer.LayerItemExtension
 import com.azavea.stac4s.extensions.asset._
+import com.github.tbouron.SpdxLicense
 import cats.data.NonEmptyList
 import cats.implicits._
+import eu.timepit.refined.types.numeric.PosInt
+import eu.timepit.refined.types.string.NonEmptyString
 import eu.timepit.refined.scalacheck.NumericInstances
 import geotrellis.vector.{Geometry, Point, Polygon}
 import io.circe.JsonObject
@@ -13,12 +18,6 @@ import org.scalacheck._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.cats.implicits._
 import java.time.Instant
-
-import com.github.tbouron.SpdxLicense
-import com.azavea.stac4s.extensions.label.LabelClassClasses.NamedLabelClasses
-import com.azavea.stac4s.extensions.label.LabelClassClasses.NumberedLabelClasses
-import com.azavea.stac4s.extensions.layer.LayerItemExtension
-import eu.timepit.refined.types.string.NonEmptyString
 
 object Generators extends NumericInstances {
 
@@ -375,10 +374,10 @@ object Generators extends NumericInstances {
   private def bandGen: Gen[Band] =
     (
       nonEmptyAlphaRefinedStringGen,
-      nonEmptyAlphaRefinedStringGen,
-      nonEmptyAlphaRefinedStringGen,
-      arbitrary[Int],
-      arbitrary[Int]
+      Gen.option(nonEmptyAlphaRefinedStringGen),
+      Gen.option(nonEmptyAlphaRefinedStringGen),
+      Gen.option(arbitrary[PosInt]),
+      Gen.option(arbitrary[PosInt])
     ).mapN(Band.apply)
 
   private def eoItemExtensionGen: Gen[EOItemExtension] =

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -67,10 +67,7 @@ object Generators extends NumericInstances {
   )
 
   private def labelLinkExtensionGen: Gen[LabelLinkExtension] =
-    Gen
-      .nonEmptyListOf(nonEmptyStringGen)
-      .map(NonEmptyList.fromListUnsafe)
-      .map(LabelLinkExtension.apply)
+    nonEmptyListGen(nonEmptyStringGen).map(LabelLinkExtension.apply)
 
   private def linkExtensionFields: Gen[JsonObject] = Gen.oneOf(
     Gen.const(().asJsonObject),
@@ -78,12 +75,12 @@ object Generators extends NumericInstances {
   )
 
   private def eoAssetExtensionGen: Gen[EOAssetExtension] =
-    nonEmptyListGen(arbitrary[Int]).map(EOAssetExtension.apply)
+    nonEmptyListGen(arbitrary[BandRange]).map(EOAssetExtension.apply)
 
-  private def assetExtensionFieldsGen: Gen[JsonObject] = Gen.oneOf(
-    Gen.const(().asJsonObject),
-    eoAssetExtensionGen.map(_.asJsonObject)
-  )
+  // private def assetExtensionFieldsGen: Gen[JsonObject] = Gen.oneOf(
+  //   Gen.const(().asJsonObject),
+  //   eoAssetExtensionGen.map(_.asJsonObject)
+  // )
 
   private def mediaTypeGen: Gen[StacMediaType] = Gen.oneOf(
     `image/tiff`,
@@ -208,7 +205,7 @@ object Generators extends NumericInstances {
       Gen.option(nonEmptyStringGen),
       Gen.containerOf[Set, StacAssetRole](assetRoleGen),
       Gen.option(mediaTypeGen),
-      assetExtensionFieldsGen
+      Gen.const(().asJsonObject)
     ) mapN {
       StacItemAsset.apply
     }
@@ -287,10 +284,10 @@ object Generators extends NumericInstances {
     }
 
   private def namedLabelClassesGen: Gen[LabelClassClasses] =
-    Gen.nonEmptyListOf(nonEmptyStringGen) map { names => NamedLabelClasses(NonEmptyList.fromListUnsafe(names)) }
+    nonEmptyListGen(nonEmptyStringGen) map { NamedLabelClasses.apply }
 
   private def numberedLabelClassesGen: Gen[LabelClassClasses] =
-    Gen.nonEmptyListOf(arbitrary[Int]) map { indices => NumberedLabelClasses(NonEmptyList.fromListUnsafe(indices)) }
+    nonEmptyListGen(arbitrary[Int]) map { NumberedLabelClasses.apply }
 
   private def labelClassClassesGen: Gen[LabelClassClasses] =
     Gen.oneOf(
@@ -362,9 +359,7 @@ object Generators extends NumericInstances {
     Gen.option(Gen.listOf(nonEmptyStringGen)).map(LabelProperties.fromOption)
 
   private def layerPropertiesGen: Gen[LayerItemExtension] =
-    Gen
-      .nonEmptyListOf(nonEmptyStringGen)
-      .map(layerIds => LayerItemExtension(NonEmptyList.fromListUnsafe(layerIds map { NonEmptyString.unsafeFrom })))
+    nonEmptyListGen(nonEmptyAlphaRefinedStringGen) map { LayerItemExtension.apply }
 
   private def labelExtensionPropertiesGen: Gen[LabelItemExtension] =
     (
@@ -489,5 +484,9 @@ object Generators extends NumericInstances {
 
   implicit val arbEOItemExtension: Arbitrary[EOItemExtension] = Arbitrary {
     eoItemExtensionGen
+  }
+
+  implicit val arbEOAssetExtension: Arbitrary[EOAssetExtension] = Arbitrary {
+    eoAssetExtensionGen
   }
 }

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -26,7 +26,7 @@ object Generators extends NumericInstances {
     Gen.listOfN(30, Gen.alphaChar) map { _.mkString }
 
   private def nonEmptyAlphaRefinedStringGen: Gen[NonEmptyString] =
-    nonEmptyStringGen map NonEmptyString.unsafeFrom 
+    nonEmptyStringGen map NonEmptyString.unsafeFrom
 
   private def nonEmptyListGen[T](g: Gen[T]): Gen[NonEmptyList[T]] =
     Gen.nonEmptyListOf(g) map { NonEmptyList.fromListUnsafe }
@@ -377,19 +377,21 @@ object Generators extends NumericInstances {
       Gen.listOf(labelOverviewGen)
     ).mapN(LabelItemExtension.apply)
 
-  private def bandGen: Gen[Band] = (
-    nonEmptyAlphaRefinedStringGen,
-    nonEmptyAlphaRefinedStringGen,
-    nonEmptyAlphaRefinedStringGen,
-    arbitrary[Int],
-    arbitrary[Int]
-  ).mapN(Band.apply)
+  private def bandGen: Gen[Band] =
+    (
+      nonEmptyAlphaRefinedStringGen,
+      nonEmptyAlphaRefinedStringGen,
+      nonEmptyAlphaRefinedStringGen,
+      arbitrary[Int],
+      arbitrary[Int]
+    ).mapN(Band.apply)
 
-  private def eoItemExtensionGen: Gen[EOItemExtension] = (
-    arbitrary[Int] map { _.toDouble }, // to avoid non-finite doubles
-    nonEmptyListGen(bandGen),
-    Gen.option(arbitrary[Percentage])
-  ).mapN(EOItemExtension.apply)
+  private def eoItemExtensionGen: Gen[EOItemExtension] =
+    (
+      arbitrary[Int] map { _.toDouble }, // to avoid non-finite doubles
+      nonEmptyListGen(bandGen),
+      Gen.option(arbitrary[Percentage])
+    ).mapN(EOItemExtension.apply)
 
   implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary {
     mediaTypeGen

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -77,10 +77,10 @@ object Generators extends NumericInstances {
   private def eoAssetExtensionGen: Gen[EOAssetExtension] =
     nonEmptyListGen(arbitrary[BandRange]).map(EOAssetExtension.apply)
 
-  // private def assetExtensionFieldsGen: Gen[JsonObject] = Gen.oneOf(
-  //   Gen.const(().asJsonObject),
-  //   eoAssetExtensionGen.map(_.asJsonObject)
-  // )
+  private def assetExtensionFieldsGen: Gen[JsonObject] = Gen.oneOf(
+    Gen.const(().asJsonObject),
+    eoAssetExtensionGen.map(_.asJsonObject)
+  )
 
   private def mediaTypeGen: Gen[StacMediaType] = Gen.oneOf(
     `image/tiff`,
@@ -205,7 +205,7 @@ object Generators extends NumericInstances {
       Gen.option(nonEmptyStringGen),
       Gen.containerOf[Set, StacAssetRole](assetRoleGen),
       Gen.option(mediaTypeGen),
-      Gen.const(().asJsonObject)
+      assetExtensionFieldsGen
     ) mapN {
       StacItemAsset.apply
     }

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -486,6 +486,10 @@ object Generators extends NumericInstances {
     eoItemExtensionGen
   }
 
+  implicit val arbBand: Arbitrary[Band] = Arbitrary {
+    bandGen
+  }
+
   implicit val arbEOAssetExtension: Arbitrary[EOAssetExtension] = Arbitrary {
     eoAssetExtensionGen
   }

--- a/modules/core/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
@@ -1,7 +1,9 @@
 package com.azavea.stac4s
 
 import com.azavea.stac4s.extensions.asset._
+import com.azavea.stac4s.extensions.eo._
 import com.azavea.stac4s.extensions.label._
+import com.azavea.stac4s.extensions.layer._
 import com.azavea.stac4s.meta._
 import Generators._
 import geotrellis.vector.Geometry
@@ -13,9 +15,6 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import java.time.Instant
-
-import com.azavea.stac4s.extensions.layer.LayerItemExtension
-import com.azavea.stac4s.extensions.eo.EOItemExtension
 
 class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with Matchers with ArbitraryInstances {
 
@@ -58,7 +57,9 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
   checkAll("Codec.LayerProperties", CodecTests[LayerItemExtension].unserializableCodec)
 
   // eo extension
-  checkAll("Codec.EO", CodecTests[EOItemExtension].unserializableCodec)
+  checkAll("Codec.EOBand", CodecTests[Band].unserializableCodec)
+  checkAll("Codec.EOItemExtension", CodecTests[EOItemExtension].unserializableCodec)
+  checkAll("Codec.EOAssetExtension", CodecTests[EOAssetExtension].unserializableCodec)
 
   // unit tests
   test("ignore optional fields") {

--- a/modules/core/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
@@ -15,6 +15,7 @@ import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import java.time.Instant
 
 import com.azavea.stac4s.extensions.layer.LayerItemExtension
+import com.azavea.stac4s.extensions.eo.EOItemExtension
 
 class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with Matchers with ArbitraryInstances {
 
@@ -55,6 +56,9 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
 
   // Layer extension
   checkAll("Codec.LayerProperties", CodecTests[LayerItemExtension].unserializableCodec)
+
+  // eo extension
+  checkAll("Codec.EO", CodecTests[EOItemExtension].unserializableCodec)
 
   // unit tests
   test("ignore optional fields") {

--- a/modules/core/src/test/scala/com/azavea/stac4s/SyntaxSpec.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/SyntaxSpec.scala
@@ -3,6 +3,7 @@ package com.azavea.stac4s
 import com.azavea.stac4s.syntax._
 import com.azavea.stac4s.extensions._
 import com.azavea.stac4s.extensions.asset._
+import com.azavea.stac4s.extensions.eo._
 import com.azavea.stac4s.extensions.label._
 import Generators._
 import cats.implicits._
@@ -57,4 +58,18 @@ class SyntaxSpec extends AnyFunSuite with Checkers with Matchers {
       stacLink.addExtensionFields(labelLinkExtension).getExtensionFields[LabelLinkExtension] == labelLinkExtension.valid
     }
   }
+
+  test("asset syntax results in the same values as typeclass summoner to extend") {
+    check { (stacItemAsset: StacItemAsset, eoAssetExtension: EOAssetExtension) =>
+      stacItemAsset.addExtensionFields(eoAssetExtension) == ItemAssetExtension[EOAssetExtension]
+        .addExtensionFields(stacItemAsset, eoAssetExtension)
+    }
+  }
+
+  test("asset syntax results in the same values as typeclass summoner to parse") {
+    check { (stacItemAsset: StacItemAsset, eoAssetExtension: EOAssetExtension) =>
+      stacItemAsset.addExtensionFields(eoAssetExtension).getExtensionFields[EOAssetExtension] == eoAssetExtension.valid
+    }
+  }
+
 }


### PR DESCRIPTION
## Overview

This PR adds case classes and typeclass evidence + tests for parsing the [EO extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/eo).

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated

### Notes

I made every field in `Band` required. In the spec every field is optional. That's [formally an oversight](https://gitter.im/SpatioTemporal-Asset-Catalog/Lobby?at=5ec57dfe9d1d2310cc38cf74). It's easy enough to make things optional later once someone has opinions about which fields if any should be required, so I'm ignoring the problem for now and demanding full bands. I could be talked into making `description` and the two wavelength indicators optional.

Closes #72 
