### PR TITLE
Fix vendor serde and missing link type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- Vendor enum (link types, media types, etc.) representations no longer prefix `vendor-` in serialization [#94](https://github.com/azavea/stac4s/pull/94)
+- Missing `derived_from` link type was included [#94](https://github.com/azavea/stac4s/pull/94)
+
 ### Security
 
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacAssetRole.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacAssetRole.scala
@@ -11,23 +11,20 @@ sealed abstract class StacAssetRole(val repr: String) {
 object StacAssetRole {
 
   implicit def eqStacAssetRole: Eq[StacAssetRole] =
-    Eq[String].imap(fromString _)({
-      case VendorAsset(s) => s
-      case fixedRole      => fixedRole.repr
-    })
+    Eq[String].imap(fromString _)(_.repr)
 
   case object Thumbnail                   extends StacAssetRole("thumbnail")
   case object Overview                    extends StacAssetRole("overview")
   case object Data                        extends StacAssetRole("data")
   case object Metadata                    extends StacAssetRole("metadata")
-  final case class VendorAsset(s: String) extends StacAssetRole("vendor")
+  final case class VendorAsset(s: String) extends StacAssetRole(s)
 
   private def fromString(s: String): StacAssetRole = s.toLowerCase match {
     case "thumbnail" => Thumbnail
     case "overview"  => Overview
     case "data"      => Data
     case "metadata"  => Metadata
-    case s           => VendorAsset(s)
+    case _           => VendorAsset(s)
   }
 
   implicit val encStacAssetRole: Encoder[StacAssetRole] =

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacAssetRole.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacAssetRole.scala
@@ -10,13 +10,17 @@ sealed abstract class StacAssetRole(val repr: String) {
 
 object StacAssetRole {
 
-  implicit def eqStacAssetRole: Eq[StacAssetRole] = Eq[String].imap(fromString _)(_.repr)
+  implicit def eqStacAssetRole: Eq[StacAssetRole] =
+    Eq[String].imap(fromString _)({
+      case VendorAsset(s) => s
+      case fixedRole      => fixedRole.repr
+    })
 
   case object Thumbnail                   extends StacAssetRole("thumbnail")
   case object Overview                    extends StacAssetRole("overview")
   case object Data                        extends StacAssetRole("data")
   case object Metadata                    extends StacAssetRole("metadata")
-  final case class VendorAsset(s: String) extends StacAssetRole(s)
+  final case class VendorAsset(s: String) extends StacAssetRole("vendor")
 
   private def fromString(s: String): StacAssetRole = s.toLowerCase match {
     case "thumbnail" => Thumbnail

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
@@ -11,36 +11,30 @@ sealed abstract class StacLinkType(val repr: String) {
 object StacLinkType {
 
   implicit def eqStacLinkType: Eq[StacLinkType] =
-    Eq[String].imap(fromString)({
-      case VendorLinkType(s) => s
-      case fixedLinkType     => fixedLinkType.repr
-    })
+    Eq[String].imap(fromString)(_.repr)
 
-  case object Self               extends StacLinkType("self")
-  case object StacRoot           extends StacLinkType("root")
-  case object Parent             extends StacLinkType("parent")
-  case object Child              extends StacLinkType("child")
-  case object Item               extends StacLinkType("item")
-  case object Items              extends StacLinkType("items")
-  case object Source             extends StacLinkType("source")
-  case object Collection         extends StacLinkType("collection")
-  case object License            extends StacLinkType("license")
-  case object Alternate          extends StacLinkType("alternate")
-  case object DescribedBy        extends StacLinkType("describedBy")
-  case object Next               extends StacLinkType("next")
-  case object Prev               extends StacLinkType("prev")
-  case object ServiceDesc        extends StacLinkType("service-desc")
-  case object ServiceDoc         extends StacLinkType("service-doc")
-  case object Conformance        extends StacLinkType("conformance")
-  case object Data               extends StacLinkType("data")
-  case object LatestVersion      extends StacLinkType("latest-version")
-  case object PredecessorVersion extends StacLinkType("predecessor-version")
-  case object SuccessorVersion   extends StacLinkType("successor-version")
-  case object DerivedFrom        extends StacLinkType("derived_from")
-
-  final case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
-    override def toString = s"$repr-$underlying"
-  }
+  case object Self                                    extends StacLinkType("self")
+  case object StacRoot                                extends StacLinkType("root")
+  case object Parent                                  extends StacLinkType("parent")
+  case object Child                                   extends StacLinkType("child")
+  case object Item                                    extends StacLinkType("item")
+  case object Items                                   extends StacLinkType("items")
+  case object Source                                  extends StacLinkType("source")
+  case object Collection                              extends StacLinkType("collection")
+  case object License                                 extends StacLinkType("license")
+  case object Alternate                               extends StacLinkType("alternate")
+  case object DescribedBy                             extends StacLinkType("describedBy")
+  case object Next                                    extends StacLinkType("next")
+  case object Prev                                    extends StacLinkType("prev")
+  case object ServiceDesc                             extends StacLinkType("service-desc")
+  case object ServiceDoc                              extends StacLinkType("service-doc")
+  case object Conformance                             extends StacLinkType("conformance")
+  case object Data                                    extends StacLinkType("data")
+  case object LatestVersion                           extends StacLinkType("latest-version")
+  case object PredecessorVersion                      extends StacLinkType("predecessor-version")
+  case object SuccessorVersion                        extends StacLinkType("successor-version")
+  case object DerivedFrom                             extends StacLinkType("derived_from")
+  final case class VendorLinkType(underlying: String) extends StacLinkType(underlying)
 
   private def fromString(s: String): StacLinkType = s.toLowerCase match {
     case "self"                => Self
@@ -64,7 +58,7 @@ object StacLinkType {
     case "predecessor-version" => PredecessorVersion
     case "successor-version"   => SuccessorVersion
     case "derived_from"        => DerivedFrom
-    case s                     => VendorLinkType(s)
+    case _                     => VendorLinkType(s)
   }
 
   implicit val encStacLinkType: Encoder[StacLinkType] =

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
@@ -10,10 +10,11 @@ sealed abstract class StacLinkType(val repr: String) {
 
 object StacLinkType {
 
-  implicit def eqStacLinkType: Eq[StacLinkType] = Eq[String].imap(fromString)({
-    case VendorLinkType(s) => s
-    case fixedLinkType => fixedLinkType.repr
-  })
+  implicit def eqStacLinkType: Eq[StacLinkType] =
+    Eq[String].imap(fromString)({
+      case VendorLinkType(s) => s
+      case fixedLinkType     => fixedLinkType.repr
+    })
 
   case object Self               extends StacLinkType("self")
   case object StacRoot           extends StacLinkType("root")

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
@@ -32,6 +32,7 @@ object StacLinkType {
   case object LatestVersion      extends StacLinkType("latest-version")
   case object PredecessorVersion extends StacLinkType("predecessor-version")
   case object SuccessorVersion   extends StacLinkType("successor-version")
+  case object DerivedFrom        extends StacLinkType("derived_from")
 
   final case class VendorLinkType(underlying: String) extends StacLinkType("vendor") {
     override def toString = s"$repr-$underlying"
@@ -58,6 +59,7 @@ object StacLinkType {
     case "latest-version"      => LatestVersion
     case "predecessor-version" => PredecessorVersion
     case "successor-version"   => SuccessorVersion
+    case "derived_from"        => DerivedFrom
     case s                     => VendorLinkType(s)
   }
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacLinkType.scala
@@ -10,7 +10,10 @@ sealed abstract class StacLinkType(val repr: String) {
 
 object StacLinkType {
 
-  implicit def eqStacLinkType: Eq[StacLinkType] = Eq[String].imap(fromString)(_.repr)
+  implicit def eqStacLinkType: Eq[StacLinkType] = Eq[String].imap(fromString)({
+    case VendorLinkType(s) => s
+    case fixedLinkType => fixedLinkType.repr
+  })
 
   case object Self               extends StacLinkType("self")
   case object StacRoot           extends StacLinkType("root")

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
@@ -10,7 +10,10 @@ sealed abstract class StacMediaType(val repr: String) {
 
 object StacMediaType {
 
-  implicit def eqStacMediaType: Eq[StacMediaType] = Eq[String].imap(fromString)(_.repr)
+  implicit def eqStacMediaType: Eq[StacMediaType] = Eq[String].imap(fromString)({
+    case VendorMediaType(s) => s
+    case fixedMediaType => fixedMediaType.repr
+  })
 
   private def fromString(s: String): StacMediaType = s match {
     case "image/tiff"                                   => `image/tiff`

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
@@ -11,10 +11,7 @@ sealed abstract class StacMediaType(val repr: String) {
 object StacMediaType {
 
   implicit def eqStacMediaType: Eq[StacMediaType] =
-    Eq[String].imap(fromString)({
-      case VendorMediaType(s) => s
-      case fixedMediaType     => fixedMediaType.repr
-    })
+    Eq[String].imap(fromString)(_.repr)
 
   private def fromString(s: String): StacMediaType = s match {
     case "image/tiff"                                   => `image/tiff`
@@ -32,7 +29,7 @@ object StacMediaType {
     case "application/geopackage+sqlite3"               => `application/geopackage+sqlite3`
     case "application/x-hdf5"                           => `application/x-hdf5`
     case "application/x-hdf"                            => `application/x-hdf`
-    case s                                              => VendorMediaType(s.split("vendor-").last)
+    case _                                              => VendorMediaType(s)
   }
 
   implicit val encMediaType: Encoder[StacMediaType] =
@@ -42,24 +39,19 @@ object StacMediaType {
     Decoder.decodeString.emap { str => Either.catchNonFatal(fromString(str)).leftMap(_ => "StacLinkType") }
 }
 
-case object `image/tiff`                     extends StacMediaType("image/tiff")
-case object `image/vnd.stac.geotiff`         extends StacMediaType("image/vnd.stac.geotiff")
-case object `image/cog`                      extends StacMediaType("image/vnd.stac.geotiff; cloud-optimized=true")
-case object `image/jp2`                      extends StacMediaType("image/jp2")
-case object `image/png`                      extends StacMediaType("image/png")
-case object `image/jpeg`                     extends StacMediaType("image/jpeg")
-case object `text/xml`                       extends StacMediaType("text/xml")
-case object `text/html`                      extends StacMediaType("text/html")
-case object `application/xml`                extends StacMediaType("application/xml")
-case object `application/json`               extends StacMediaType("application/json")
-case object `text/plain`                     extends StacMediaType("text/plain")
-case object `application/geo+json`           extends StacMediaType("application/geo+json")
-case object `application/geopackage+sqlite3` extends StacMediaType("application/geopackage+sqlite3")
-case object `application/x-hdf5`             extends StacMediaType("application/x-hdf5")
-case object `application/x-hdf`              extends StacMediaType("application/x-hdf")
-
-final case class VendorMediaType(underlying: String) extends StacMediaType("vendor") {
-
-  override def toString =
-    s"$repr-$underlying"
-}
+case object `image/tiff`                             extends StacMediaType("image/tiff")
+case object `image/vnd.stac.geotiff`                 extends StacMediaType("image/vnd.stac.geotiff")
+case object `image/cog`                              extends StacMediaType("image/vnd.stac.geotiff; cloud-optimized=true")
+case object `image/jp2`                              extends StacMediaType("image/jp2")
+case object `image/png`                              extends StacMediaType("image/png")
+case object `image/jpeg`                             extends StacMediaType("image/jpeg")
+case object `text/xml`                               extends StacMediaType("text/xml")
+case object `text/html`                              extends StacMediaType("text/html")
+case object `application/xml`                        extends StacMediaType("application/xml")
+case object `application/json`                       extends StacMediaType("application/json")
+case object `text/plain`                             extends StacMediaType("text/plain")
+case object `application/geo+json`                   extends StacMediaType("application/geo+json")
+case object `application/geopackage+sqlite3`         extends StacMediaType("application/geopackage+sqlite3")
+case object `application/x-hdf5`                     extends StacMediaType("application/x-hdf5")
+case object `application/x-hdf`                      extends StacMediaType("application/x-hdf")
+final case class VendorMediaType(underlying: String) extends StacMediaType(underlying)

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacMediaType.scala
@@ -10,10 +10,11 @@ sealed abstract class StacMediaType(val repr: String) {
 
 object StacMediaType {
 
-  implicit def eqStacMediaType: Eq[StacMediaType] = Eq[String].imap(fromString)({
-    case VendorMediaType(s) => s
-    case fixedMediaType => fixedMediaType.repr
-  })
+  implicit def eqStacMediaType: Eq[StacMediaType] =
+    Eq[String].imap(fromString)({
+      case VendorMediaType(s) => s
+      case fixedMediaType     => fixedMediaType.repr
+    })
 
   private def fromString(s: String): StacMediaType = s match {
     case "image/tiff"                                   => `image/tiff`

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelMethod.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelMethod.scala
@@ -11,9 +11,12 @@ sealed abstract class LabelMethod(val repr: String) {
 object LabelMethod {
   case object Manual                          extends LabelMethod("manual")
   case object Automatic                       extends LabelMethod("automatic")
-  case class VendorMethod(methodName: String) extends LabelMethod(methodName)
+  case class VendorMethod(methodName: String) extends LabelMethod("vendor")
 
-  implicit def eqLabelMethod: Eq[LabelMethod] = Eq[String].imap(fromString _)(_.repr)
+  implicit def eqLabelMethod: Eq[LabelMethod] = Eq[String].imap(fromString _)({
+    case VendorMethod(s) => s
+    case fixedMethod => fixedMethod.repr
+  })
 
   implicit val decLabelMethod: Decoder[LabelMethod] = Decoder[String].map(fromString _)
   implicit val encLabelMethod: Encoder[LabelMethod] = Encoder[String].contramap(_.repr)

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelMethod.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelMethod.scala
@@ -11,12 +11,9 @@ sealed abstract class LabelMethod(val repr: String) {
 object LabelMethod {
   case object Manual                          extends LabelMethod("manual")
   case object Automatic                       extends LabelMethod("automatic")
-  case class VendorMethod(methodName: String) extends LabelMethod("vendor")
+  case class VendorMethod(methodName: String) extends LabelMethod(methodName)
 
-  implicit def eqLabelMethod: Eq[LabelMethod] = Eq[String].imap(fromString _)({
-    case VendorMethod(s) => s
-    case fixedMethod => fixedMethod.repr
-  })
+  implicit def eqLabelMethod: Eq[LabelMethod] = Eq[String].imap(fromString _)(_.repr)
 
   implicit val decLabelMethod: Decoder[LabelMethod] = Decoder[String].map(fromString _)
   implicit val encLabelMethod: Encoder[LabelMethod] = Encoder[String].contramap(_.repr)
@@ -24,6 +21,6 @@ object LabelMethod {
   def fromString(s: String): LabelMethod = s.toLowerCase match {
     case "manual"    => Manual
     case "automatic" => Automatic
-    case s           => VendorMethod(s)
+    case _           => VendorMethod(s)
   }
 }

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelTask.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelTask.scala
@@ -14,9 +14,12 @@ object LabelTask {
   case object Segmentation                extends LabelTask("segmentation")
   case object Detection                   extends LabelTask("detection")
   case object Classification              extends LabelTask("classification")
-  case class VendorTask(taskName: String) extends LabelTask(taskName)
+  case class VendorTask(taskName: String) extends LabelTask("vendor")
 
-  implicit def eqLabelTask: Eq[LabelTask] = Eq[String].imap(fromString _)(_.repr)
+  implicit def eqLabelTask: Eq[LabelTask] = Eq[String].imap(fromString _)({
+    case VendorTask(s) => s
+    case fixedTask => fixedTask.repr
+  })
 
   implicit val decLabelTask: Decoder[LabelTask] = Decoder[String].map(fromString _)
   implicit val encLabelTask: Encoder[LabelTask] = Encoder[String].contramap(_.repr)

--- a/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelTask.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/extensions/label/LabelTask.scala
@@ -14,12 +14,9 @@ object LabelTask {
   case object Segmentation                extends LabelTask("segmentation")
   case object Detection                   extends LabelTask("detection")
   case object Classification              extends LabelTask("classification")
-  case class VendorTask(taskName: String) extends LabelTask("vendor")
+  case class VendorTask(taskName: String) extends LabelTask(taskName)
 
-  implicit def eqLabelTask: Eq[LabelTask] = Eq[String].imap(fromString _)({
-    case VendorTask(s) => s
-    case fixedTask => fixedTask.repr
-  })
+  implicit def eqLabelTask: Eq[LabelTask] = Eq[String].imap(fromString _)(_.repr)
 
   implicit val decLabelTask: Decoder[LabelTask] = Decoder[String].map(fromString _)
   implicit val encLabelTask: Encoder[LabelTask] = Encoder[String].contramap(_.repr)
@@ -29,6 +26,6 @@ object LabelTask {
     case "segmentation"   => Segmentation
     case "detection"      => Detection
     case "classification" => Classification
-    case s                => VendorTask(s)
+    case _                => VendorTask(s)
   }
 }

--- a/modules/core/src/test/resources/catalogs/landsat-stac-layers/landsat-8-l1/2014-153/LC81530252014153LGN00.json
+++ b/modules/core/src/test/resources/catalogs/landsat-stac-layers/landsat-8-l1/2014-153/LC81530252014153LGN00.json
@@ -133,7 +133,7 @@
       "roles" : [
         "metadata"
       ],
-      "type" : "vendor-mtl"
+      "type" : "mtl"
     },
     "B4" : {
       "href" : "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B4.TIF",

--- a/modules/core/src/test/resources/catalogs/landsat-stac/landsat-8-l1/2014-153/LC81530252014153LGN00.json
+++ b/modules/core/src/test/resources/catalogs/landsat-stac/landsat-8-l1/2014-153/LC81530252014153LGN00.json
@@ -132,7 +132,7 @@
       "roles" : [
         "metadata"
       ],
-      "type" : "vendor-mtl"
+      "type" : "mtl"
     },
     "B4" : {
       "href" : "http://landsat-pds.s3.amazonaws.com/L8/153/025/LC81530252014153LGN00/LC81530252014153LGN00_B4.TIF",

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -82,55 +82,55 @@ object Generators extends NumericInstances {
   )
 
   private def mediaTypeGen: Gen[StacMediaType] = Gen.oneOf(
-    `image/tiff`,
-    `image/vnd.stac.geotiff`,
-    `image/cog`,
-    `image/jp2`,
-    `image/png`,
-    `image/jpeg`,
-    `text/xml`,
-    `text/html`,
-    `application/xml`,
-    `application/json`,
-    `text/plain`,
-    `application/geo+json`,
-    `application/geopackage+sqlite3`,
-    `application/x-hdf5`,
-    `application/x-hdf`,
-    VendorMediaType("test-media-type")
+    Gen.const(`image/tiff`),
+    Gen.const(`image/vnd.stac.geotiff`),
+    Gen.const(`image/cog`),
+    Gen.const(`image/jp2`),
+    Gen.const(`image/png`),
+    Gen.const(`image/jpeg`),
+    Gen.const(`text/xml`),
+    Gen.const(`text/html`),
+    Gen.const(`application/xml`),
+    Gen.const(`application/json`),
+    Gen.const(`text/plain`),
+    Gen.const(`application/geo+json`),
+    Gen.const(`application/geopackage+sqlite3`),
+    Gen.const(`application/x-hdf5`),
+    Gen.const(`application/x-hdf`),
+    nonEmptyStringGen map VendorMediaType.apply
   )
 
   private def linkTypeGen: Gen[StacLinkType] = Gen.oneOf(
-    StacLinkType.Self,
-    StacLinkType.StacRoot,
-    StacLinkType.Parent,
-    StacLinkType.Child,
-    StacLinkType.Item,
-    StacLinkType.Items,
-    StacLinkType.Source,
-    StacLinkType.Collection,
-    StacLinkType.License,
-    StacLinkType.Alternate,
-    StacLinkType.DescribedBy,
-    StacLinkType.Next,
-    StacLinkType.Prev,
-    StacLinkType.ServiceDesc,
-    StacLinkType.ServiceDoc,
-    StacLinkType.Conformance,
-    StacLinkType.Data,
-    StacLinkType.LatestVersion,
-    StacLinkType.PredecessorVersion,
-    StacLinkType.SuccessorVersion,
-    StacLinkType.DerivedFrom,
-    StacLinkType.VendorLinkType("test-link")
+    Gen.const(StacLinkType.Self),
+    Gen.const(StacLinkType.StacRoot),
+    Gen.const(StacLinkType.Parent),
+    Gen.const(StacLinkType.Child),
+    Gen.const(StacLinkType.Item),
+    Gen.const(StacLinkType.Items),
+    Gen.const(StacLinkType.Source),
+    Gen.const(StacLinkType.Collection),
+    Gen.const(StacLinkType.License),
+    Gen.const(StacLinkType.Alternate),
+    Gen.const(StacLinkType.DescribedBy),
+    Gen.const(StacLinkType.Next),
+    Gen.const(StacLinkType.Prev),
+    Gen.const(StacLinkType.ServiceDesc),
+    Gen.const(StacLinkType.ServiceDoc),
+    Gen.const(StacLinkType.Conformance),
+    Gen.const(StacLinkType.Data),
+    Gen.const(StacLinkType.LatestVersion),
+    Gen.const(StacLinkType.PredecessorVersion),
+    Gen.const(StacLinkType.SuccessorVersion),
+    Gen.const(StacLinkType.DerivedFrom),
+    nonEmptyStringGen map StacLinkType.VendorLinkType.apply
   )
 
   private def assetRoleGen: Gen[StacAssetRole] = Gen.oneOf(
-    StacAssetRole.Thumbnail,
-    StacAssetRole.Overview,
-    StacAssetRole.Data,
-    StacAssetRole.Metadata,
-    StacAssetRole.VendorAsset("test-asset")
+    Gen.const(StacAssetRole.Thumbnail),
+    Gen.const(StacAssetRole.Overview),
+    Gen.const(StacAssetRole.Data),
+    Gen.const(StacAssetRole.Metadata),
+    nonEmptyStringGen map StacAssetRole.VendorAsset.apply
   )
 
   private def providerRoleGen: Gen[StacProviderRole] = Gen.oneOf(
@@ -330,22 +330,20 @@ object Generators extends NumericInstances {
     labelOverviewWithStats
   )
 
-  private def labelTaskGen: Gen[LabelTask] = Gen.oneOf(
+  private def labelTaskGen: Gen[LabelTask] =
     Gen.oneOf(
-      LabelTask.Classification,
-      LabelTask.Detection,
-      LabelTask.Regression,
-      LabelTask.Segmentation,
-      LabelTask.VendorTask("test-label-task")
-    ),
-    nonEmptyStringGen map { s => LabelTask.VendorTask(s.toLowerCase) }
-  )
+      Gen.const(LabelTask.Classification),
+      Gen.const(LabelTask.Detection),
+      Gen.const(LabelTask.Regression),
+      Gen.const(LabelTask.Segmentation),
+      nonEmptyStringGen map LabelTask.VendorTask.apply
+    )
 
   private def labelMethodGen: Gen[LabelMethod] = Gen.oneOf(
     Gen.oneOf(
-      LabelMethod.Automatic,
-      LabelMethod.Manual,
-      LabelMethod.VendorMethod("test-label-vendor-method")
+      Gen.const(LabelMethod.Automatic),
+      Gen.const(LabelMethod.Manual),
+      nonEmptyStringGen map LabelMethod.VendorMethod.apply
     ),
     nonEmptyStringGen map LabelMethod.fromString
   )

--- a/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
+++ b/modules/core/src/test/scala/com/azavea/stac4s/Generators.scala
@@ -121,6 +121,7 @@ object Generators extends NumericInstances {
     StacLinkType.LatestVersion,
     StacLinkType.PredecessorVersion,
     StacLinkType.SuccessorVersion,
+    StacLinkType.DerivedFrom,
     StacLinkType.VendorLinkType("test-link")
   )
 


### PR DESCRIPTION
## Overview

This PR:

- makes the `VendorFoo` enums for link types, media types, label tasks, label methods, and asset roles consistent (`extends Foo(s)` instead of `extends Foo("vendor")`)
- adds a missing `StacLinkType` to the known list

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated

### Testing

- tests

Closes #68 

Closes #66 