### PR TITLE
Make properties field optional on collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Decoding collections from json does not require the `properties` field [#97](https://github.com/azavea/stac4s/pull/97)
+
 ### Security
 
 

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacCollection.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacCollection.scala
@@ -73,7 +73,7 @@ object StacCollection {
       c.get[Option[List[StacProvider]]]("providers"),
       c.get[StacExtent]("extent"),
       c.get[Option[JsonObject]]("summaries"),
-      c.get[JsonObject]("properties"),
+      c.get[Option[JsonObject]]("properties"),
       c.get[List[StacLink]]("links"),
       c.value.as[JsonObject]
     ).mapN(
@@ -88,7 +88,7 @@ object StacCollection {
           providers: Option[List[StacProvider]],
           extent: StacExtent,
           summaries: Option[JsonObject],
-          properties: JsonObject,
+          properties: Option[JsonObject],
           links: List[StacLink],
           extensionFields: JsonObject
       ) =>
@@ -103,7 +103,7 @@ object StacCollection {
           providers getOrElse List.empty,
           extent,
           summaries getOrElse JsonObject.fromMap(Map.empty),
-          properties,
+          properties getOrElse JsonObject.fromMap(Map.empty),
           links,
           extensionFields.filter({
             case (k, _) => !collectionFields.contains(k)


### PR DESCRIPTION
## Overview

This PR makes decoding `properties` in collection json optional. It's still required on the object but not required in the input json. It's a bug that would have been caught by circe-golden (#88) I think if we were using it :(

### Checklist

- ~New tests have been added or existing tests have been modified~
- [x] Changelog updated