### PR TITLE
Receive GPG key while publishing artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,6 @@ workflows:
               only:
                 - /^(.*)$/
             branches:
-              only:
-                - feature/cek/receive-gpg-key
               ignore:
                 - /^(.*)$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ aliases:
     - run:
         name: "Import signing key"
         command: |
+          gpg --keyserver keyserver.ubuntu.com \
+            --recv-keys 0x713F9F29598CFFF3 && \
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
           gpg --import signing_key.asc
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,7 @@ aliases:
         name: "Import signing key"
         command: |
           echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
-          gpg --batch \
-            --passphrase "${GPG_PASSPHRASE}" \
-            --import signing_key.asc
+          gpg --import signing_key.asc
     - run:
         name: Executing cipublish
         command: ./scripts/cipublish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,8 @@ workflows:
               only:
                 - /^(.*)$/
             branches:
+              only:
+                - feature/cek/receive-gpg-key
               ignore:
                 - /^(.*)$/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Receive GPG key while publishing artifacts [#101](https://github.com/azavea/stac4s/pull/101)
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
## Overview

This retrieves an up-to-date copy of the Azavea public GPG key during the `run_cipublish` build stage.

The CircleCI build will now retrieve the latest copy of the public key, allowing us to renew the key in the future by pushing a new signature with an extended expiration date to public keyservers.

### Checklist

~- [ ] New tests have been added or existing tests have been modified~
- [x] Changelog updated

## Testing Instructions

- Verify that a valid Azavea GPG key is retrieved from a public keyserver and verified during `run_cipublish`.
  - This key was retrieved in [this job run](https://circleci.com/gh/azavea/stac4s/262).

Connects azavea/operations#446
