### PR TITLE
Extensions are not required on catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- STAC Catalogs do not require the `stac_extensions` field [#127](https://github.com/azavea/stac4s/pull/127)
+
 ### Security
 
 ## [0.0.10](https://github.com/azavea/stac4s/tree/0.0.10)

--- a/modules/core/src/main/scala/com/azavea/stac4s/StacCatalog.scala
+++ b/modules/core/src/main/scala/com/azavea/stac4s/StacCatalog.scala
@@ -40,7 +40,7 @@ object StacCatalog {
   implicit val decCatalog: Decoder[StacCatalog] = { c: HCursor =>
     (
       c.get[String]("stac_version"),
-      c.get[List[String]]("stac_extensions"),
+      c.get[Option[List[String]]]("stac_extensions"),
       c.get[String]("id"),
       c.get[Option[String]]("title"),
       c.get[String]("description"),
@@ -49,7 +49,7 @@ object StacCatalog {
     ).mapN(
       (
           version: String,
-          extensions: List[String],
+          extensions: Option[List[String]],
           id: String,
           title: Option[String],
           description: String,
@@ -58,7 +58,7 @@ object StacCatalog {
       ) =>
         StacCatalog.apply(
           version,
-          extensions,
+          extensions getOrElse Nil,
           id,
           title,
           description,


### PR DESCRIPTION
## Overview

This PR makes `stac_extensions` optional when decoding catalogs.

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated

## Testing Instructions

- make sure that everywhere we try to get a field named `stac_extensions` when decoding, we ask for an `Option[List[String]]` instead of a `List[String]`

Closes #121