### PR TITLE
Update release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,17 @@ Contributions can be made via [pull requests](https://github.com/azavea/stac4s/p
 
 ### Deployments, Releases, and Maintenance
 
-`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release make an annotated tag and push it to the repository:
+`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release, rotate changelog entries into a section for the version you're releasing, then make an annotated tag and push it to the repository:
 
 ```
-git tag -a <version> -m "Release version <version>
+git tag -s -a <version> -m "Release version <version>
 git push origin --tags
 ```
+
+After you've pushed the tag, navigate to [Releases](https://github.com/azavea/stac4s/releases) and
+choose "Draft a new release". Choose your tag version, title the release for your tag version,
+and then copy the changelog section for this release into the description (leaving out the heading for
+the version).
 
 Active development and backports for a particular _minor_ version of `stac4s` will be tracked and maintained on a branch for that series (e.g. `series/0.1.x`, `series/0.2.x`, etc). Pull requests to backport a fix, feature, or other change should be made to that series' respective branch.
 


### PR DESCRIPTION
## Overview

This PR updates the release docs to explain the GitHub release process. Releases get us nice artifacts like well separated changelog
sections for each release, easy "latest" tracking, and the ability to use create pre-release versions that don't show up as "latest".

### Checklist

- ~Changelog updated~ I'm thinking probably not for this