### PR TITLE
Ignore .bsp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ project/plugins/project/
 .ensime
 .metals/*
 .metals
+.bsp/*
+.bsp
 /.ivy2/*
 .sbt/
 metals.lock.db


### PR DESCRIPTION
## Overview

After upgrade to sbt 1.4.*, we have a nice .bsp directory. We don't want it committed and it's just `git status` noise.

### Checklist

- ~Changelog updated~
