### PR TITLE
Only deploy tags if they start with `v`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^(\d.*)$/
+                - /^(v.*)$/
       - "openjdk8-scala2.12_deploy":
           context: sonatype-azavea-signing-key
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^(.*)$/
+                - /^(\d.*)$/
       - "openjdk8-scala2.12_deploy":
           context: sonatype-azavea-signing-key
           requires:
@@ -57,7 +57,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^(.*)$/
+                - /^(\d.*)$/
             branches:
               ignore:
                 - /^(.*)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ workflows:
           filters:
             tags:
               only:
-                - /^(\d.*)$/
+                - /^(v.*)$/
             branches:
               ignore:
                 - /^(.*)$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Told circle not to publish tags that don't start with numbers [#190](https://github.com/azavea/stac4s/pull/190)
 
 ## [0.0.21] - 2021-01-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 ### Fixed
-- Told circle not to publish tags that don't start with numbers [#190](https://github.com/azavea/stac4s/pull/190)
+- Told circle only to publish tags that start with `v` [#190](https://github.com/azavea/stac4s/pull/190)
 
 ## [0.0.21] - 2021-01-08
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@ Contributions can be made via [pull requests](https://github.com/azavea/stac4s/p
 
 ### Deployments, Releases, and Maintenance
 
-`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release, rotate changelog entries into a section for the version you're releasing usin `chan release X.Y.Z`, then make an annotated tag and push it to the repository:
+`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release:
 
-```
-git tag -s -a <version> -m "Release version <version>
-git push origin --tags
+- make sure `master` is up-to-date: `git checkout master && git pull origin master`
+- rotate changelog entries into a section for the version you're releasing using `chan release X.Y.Z`
+- commit your changelog rotation: `git commit -am "Release X.Y.Z"`
+- make and push an annotated tag for your release and push `master`:
+
+```bash
+$ git tag -s -a vX.Y.Z -m "Release version <version>"
+$ git push origin --tags
+$ git push origin master
 ```
 
 After you've pushed the tag, create a GitHub release using `chan gh-release X.Y.Z`.

--- a/docs/stac-api-spec/extensions/layer/README.md
+++ b/docs/stac-api-spec/extensions/layer/README.md
@@ -39,7 +39,7 @@ Request to `GET /layers`:
 
 ```javascript
 {
-    "stac_version": "1.0.0-beta.1",
+    "stac_version": "1.0.0-beta.2",
     "stac_extensions": [],
     "id": "layer-us-global",
     "title": "Landsat 8 L1",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/catalog.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-beta.1",
+  "stac_version": "1.0.0-beta.2",
   "stac_extensions": [],
   "id": "landsat-stac-layers",
   "title": "STAC for Landsat data",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-05/LC80150322018141LGN00.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-05/LC80150322018141LGN00.json
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "id": "LC80150322018141LGN00",
-  "stac_version" : "1.0.0-beta.1",
+  "stac_version" : "1.0.0-beta.2",
   "stac_extensions" : [
     "eo",
     "view",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-06/LC80140332018166LGN00.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-06/LC80140332018166LGN00.json
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "id": "LC80140332018166LGN00",
-  "stac_version" : "1.0.0-beta.1",
+  "stac_version" : "1.0.0-beta.2",
   "stac_extensions" : [
     "eo",
     "view",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-06/LC80300332018166LGN00.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-06/LC80300332018166LGN00.json
@@ -1,6 +1,6 @@
 {
   "type": "Feature",
-  "stac_version" : "1.0.0-beta.1",
+  "stac_version" : "1.0.0-beta.2",
   "stac_extensions" : [
     "eo",
     "view",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-07/LC80150332018189LGN00.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/2018-07/LC80150332018189LGN00.json
@@ -1,7 +1,7 @@
 {
   "type": "Feature",
   "id": "LC80150332018189LGN00",
-  "stac_version" : "1.0.0-beta.1",
+  "stac_version" : "1.0.0-beta.2",
   "stac_extensions" : [
     "eo",
     "view",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/catalog.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/landsat-8-l1/catalog.json
@@ -1,5 +1,5 @@
 {
-  "stac_version" : "1.0.0-beta.1",
+  "stac_version" : "1.0.0-beta.2",
   "stac_extensions" : [
     "eo",
     "view",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/catalog.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/catalog.json
@@ -1,5 +1,5 @@
 {
-    "stac_version": "1.0.0-beta.1",
+    "stac_version": "1.0.0-beta.2",
     "stac_extensions": [],
     "id": "layer-us-global",
     "title": "Landsat 8 L1",

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/pa.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/pa.json
@@ -1,7 +1,7 @@
 {
     "type": "Feature",
     "id": "layer-pa",
-    "stac_version": "1.0.0-beta.1",
+    "stac_version": "1.0.0-beta.2",
     "stac_extensions": [
         "layer"
     ],

--- a/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/us.json
+++ b/docs/stac-spec/extensions/layer/examples/landsat-stac-layers/layers/us.json
@@ -1,7 +1,7 @@
 {
     "type": "Feature",
     "id": "layer-us",
-    "stac_version": "1.0.0-beta.1",
+    "stac_version": "1.0.0-beta.2",
     "stac_extensions": [
         "layer"
     ],

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
@@ -7,7 +7,7 @@ final case class ValidStacVersion()
 object ValidStacVersion {
 
   val stacVersions = List(
-    "1.0.0-beta2"
+    "1.0.0-beta.2"
   )
 
   implicit def validStacVersion: Validate.Plain[String, ValidStacVersion] =

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
@@ -7,7 +7,7 @@ final case class ValidStacVersion()
 object ValidStacVersion {
 
   val stacVersions = List(
-    "0.9.0"
+    "1.0.0-beta2"
   )
 
   implicit def validStacVersion: Validate.Plain[String, ValidStacVersion] =

--- a/modules/testing/js/src/main/scala/JsInstances.scala
+++ b/modules/testing/js/src/main/scala/JsInstances.scala
@@ -84,7 +84,7 @@ trait JsInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("0.9.0")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -94,7 +94,7 @@ trait JsInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("0.9.0")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
       Gen.const(Nil),
       Gen.listOfN[StacItem](2, stacItemGen),
       Gen.const(Nil),
@@ -103,7 +103,7 @@ trait JsInstances {
 
   private[testing] def stacCollectionShortGen: Gen[StacCollection] =
     (
-      Gen.const("0.9.0"),
+      Gen.const("1.0.0-beta2"),
       Gen.const(Nil),
       nonEmptyStringGen,
       nonEmptyStringGen.map(_.some),

--- a/modules/testing/js/src/main/scala/JsInstances.scala
+++ b/modules/testing/js/src/main/scala/JsInstances.scala
@@ -84,7 +84,7 @@ trait JsInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -94,7 +94,7 @@ trait JsInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
       Gen.const(Nil),
       Gen.listOfN[StacItem](2, stacItemGen),
       Gen.const(Nil),
@@ -103,7 +103,7 @@ trait JsInstances {
 
   private[testing] def stacCollectionShortGen: Gen[StacCollection] =
     (
-      Gen.const("1.0.0-beta2"),
+      Gen.const("1.0.0-beta.2"),
       Gen.const(Nil),
       nonEmptyStringGen,
       nonEmptyStringGen.map(_.some),

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -79,7 +79,7 @@ trait JvmInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -89,7 +89,7 @@ trait JvmInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.const(Nil),

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -79,7 +79,7 @@ trait JvmInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("0.9.0")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -89,7 +89,7 @@ trait JvmInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("0.9.0")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-beta2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.const(Nil),


### PR DESCRIPTION
## Overview

Our release instructions include `chan gh-release <semver>`. Unfortunately, this pushes a tag starting with `v`, so we end up double-publishing the version we're releasing. With this PR, Circle ignores those tags:

![image](https://user-images.githubusercontent.com/5702984/101959741-27f59700-3bc3-11eb-9f58-2a383ba57fc5.png)

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

## Notes

It's not perfect... the `gh-release` creates links between the `v` tags that `chan` likes, so we can't delete those without breaking the links in the `gh-release`. I'm not totally sure what to do here, so I'm going to leave things up and hope to talk about it next week.