### PR TITLE
Update release instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Use chan for all release tasks [#200](https://github.com/azavea/stac4s/pull/200)
 
 ## [0.0.20] - 2021-01-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+
+## [0.0.20] - 2021-01-04
 ### Added
 - Сlient module [#140](https://github.com/azavea/stac4s/pull/140)
 
@@ -90,7 +92,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 - Removed `core` from package naming [#5](https://github.com/azavea/stac4s/pull/5)
 
-[Unreleased]: https://github.com/azavea/stac4s/compare/v0.0.19...HEAD
+[Unreleased]: https://github.com/azavea/stac4s/compare/v0.0.20...HEAD
+[0.0.20]: https://github.com/azavea/stac4s/compare/v0.0.19...v0.0.20
 [0.0.19]: https://github.com/azavea/stac4s/compare/v0.0.18...v0.0.19
 [0.0.18]: https://github.com/azavea/stac4s/compare/v0.0.17...v0.0.18
 [0.0.17]: https://github.com/azavea/stac4s/compare/v0.0.16...v0.0.17

--- a/README.md
+++ b/README.md
@@ -27,14 +27,19 @@ Contributions can be made via [pull requests](https://github.com/azavea/stac4s/p
 
 ### Deployments, Releases, and Maintenance
 
-`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release, rotate changelog entries into a section for the version you're releasing usin `chan release X.Y.Z`, then make an annotated tag and push it to the repository:
+`master` signals the current unreleased, actively developed codebase. Each release will have an associated `git tag` and is handled automatically via a CI job once a tag is pushed. Releases are handled automatically in CI. To produce a release, rotate changelog entries into a section for the version you're releasing using `chan release X.Y.Z`, then commit that changelog change:
 
 ```
-git tag -s -a <version> -m "Release version <version>
-git push origin --tags
+$ git add CHANGELOG.md
+$ git commit -m "X.Y.Z"
 ```
 
-After you've pushed the tag, create a GitHub release using `chan gh-release X.Y.Z`.
+Then create a release with `chan`. To do so, you'll need a [GitHub access token](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token).
+
+```
+$ export GITHUB_TOKEN=<your token>
+$ chan gh-release
+```
 
 Active development and backports for a particular _minor_ version of `stac4s` will be tracked and maintained on a branch for that series (e.g. `series/0.1.x`, `series/0.2.x`, etc). Pull requests to backport a fix, feature, or other change should be made to that series' respective branch.
 


### PR DESCRIPTION
## Overview

This PR updates release instructions to use `chan` for everything. The reason to do so is that `chan gh-release` handles tagging, pushing the tag, and creating GitHub releases, so when we had a separate tagging step we wound up with duplicated tags:

![image](https://user-images.githubusercontent.com/5702984/103552233-d1e5dd80-4e68-11eb-8880-7025e4dc61c0.png)

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

Follow up to #190 
