### PR TITLE
Review client specs and make them more deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Fixed
 - Told circle only to publish tags that start with `v` [#190](https://github.com/azavea/stac4s/pull/190)
-
-### Fixed
 - Review client specs and make them more deterministic [#212](https://github.com/azavea/stac4s/pull/212)
 
 ## [0.0.21] - 2021-01-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Told circle only to publish tags that start with `v` [#190](https://github.com/azavea/stac4s/pull/190)
 
+### Fixed
+- Review client specs and make them more deterministic [#212](https://github.com/azavea/stac4s/pull/212)
+
 ## [0.0.21] - 2021-01-08
 ### Fixed
 - Fix Client signatures [#210](https://github.com/azavea/stac4s/pull/210)

--- a/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
+++ b/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
@@ -7,6 +7,7 @@ import eu.timepit.refined.types.all.NonEmptyString
 import io.circe.JsonObject
 import io.circe.syntax._
 import org.scalacheck.Arbitrary
+import org.scalacheck.resample._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
@@ -28,7 +29,7 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .whenRequestMatches(_.uri.path == Seq("search"))
       .thenRespondF { _ =>
         Response
-          .ok(arbItemCollectionShort.arbitrary.sample.asJson.asRight)
+          .ok(arbItemCollectionShort.arbitrary.resample().asJson.asRight)
           .asRight
       }
       .whenRequestMatches {
@@ -46,7 +47,7 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       }
       .thenRespondF { _ =>
         Response
-          .ok(arbCollectionShort.arbitrary.sample.toRight("Collection generation failure."))
+          .ok(arbCollectionShort.arbitrary.resample().asRight)
           .asRight
       }
       .whenRequestMatches {
@@ -61,7 +62,7 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       .whenRequestMatches(_.uri.path == Seq("collections", "collection_id", "items", "item_id"))
       .thenRespondF { _ =>
         Response
-          .ok(arbItemShort.arbitrary.sample.toRight("Item generation failure."))
+          .ok(arbItemShort.arbitrary.resample().asRight)
           .asRight
       }
       .whenRequestMatches {
@@ -70,7 +71,7 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       }
       .thenRespondF { _ =>
         Response
-          .ok(arbItemShort.arbitrary.sample.get.asRight)
+          .ok(arbItemShort.arbitrary.resample().asRight)
           .asRight
       }
       .whenRequestMatches {
@@ -79,7 +80,7 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       }
       .thenRespondF { _ =>
         Response
-          .ok(arbCollectionShort.arbitrary.sample.get.asRight)
+          .ok(arbCollectionShort.arbitrary.resample().asRight)
           .asRight
       }
 
@@ -87,13 +88,11 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     it("search") {
       client.search
         .valueOr(throw _)
-        .size should be > 0
     }
 
     it("collections") {
       client.collections
         .valueOr(throw _)
-        .size should be > 0
     }
 
     it("collection") {
@@ -106,7 +105,6 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
       client
         .items(NonEmptyString.unsafeFrom("collection_id"))
         .valueOr(throw _)
-        .size should be > 0
     }
 
     it("item") {
@@ -118,13 +116,15 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
     it("itemCreate") {
       client
         .itemCreate(NonEmptyString.unsafeFrom("collection_id"), arbItemShort.arbitrary.sample.get)
-        .map(_.id should not be empty)
+        .valueOr(throw _)
+        .id should not be empty
     }
 
     it("collectionCreate") {
       client
         .collectionCreate(arbCollectionShort.arbitrary.sample.get)
-        .map(_.id should not be empty)
+        .valueOr(throw _)
+        .id should not be empty
     }
   }
 

--- a/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
+++ b/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
@@ -115,14 +115,14 @@ trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAl
 
     it("itemCreate") {
       client
-        .itemCreate(NonEmptyString.unsafeFrom("collection_id"), arbItemShort.arbitrary.sample.get)
+        .itemCreate(NonEmptyString.unsafeFrom("collection_id"), arbItemShort.arbitrary.resample())
         .valueOr(throw _)
         .id should not be empty
     }
 
     it("collectionCreate") {
       client
-        .collectionCreate(arbCollectionShort.arbitrary.sample.get)
+        .collectionCreate(arbCollectionShort.arbitrary.resample())
         .valueOr(throw _)
         .id should not be empty
     }

--- a/modules/client/shared/src/test/scala/org/scalacheck/resample/package.scala
+++ b/modules/client/shared/src/test/scala/org/scalacheck/resample/package.scala
@@ -1,0 +1,22 @@
+package org.scalacheck
+
+import scala.annotation.tailrec
+
+package object resample {
+
+  /** https://github.com/typelevel/scalacheck/issues/650#issuecomment-625384900 */
+  implicit class GenOps[A](val g: Gen[A]) extends AnyVal {
+
+    def resample(retries: Int = 1000): A = {
+      @tailrec
+      def loop(tries: Int): A =
+        if (tries >= retries) sys.error("Generator failed to produce a non-empty result.")
+        else
+          g.sample match {
+            case Some(a) => a
+            case None    => loop(tries + 1)
+          }
+      loop(0)
+    }
+  }
+}


### PR DESCRIPTION
## Overview


This PR:
- Makes tests more prescise (i.e. empty list result is an expected result and should not fail)
- Removes `generator.sample.get` calls with the `resample` function taken from here: https://github.com/typelevel/scalacheck/issues/650#issuecomment-625384900

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

Closes #211
