### PR TITLE
Add and test layer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Told circle only to publish tags that start with `v` [#190](https://github.com/azavea/stac4s/pull/190)
 - Review client specs and make them more deterministic [#212](https://github.com/azavea/stac4s/pull/212)
 
+### Added
+- Added `StacLayer` and `StacLayerProperties` types [#252](https://github.com/azavea/stac4s/pull/252)
+
 ## [0.0.21] - 2021-01-08
 ### Fixed
 - Fix Client signatures [#210](https://github.com/azavea/stac4s/pull/210)

--- a/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
+++ b/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
@@ -12,6 +12,7 @@ import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 import java.time.Instant
+import com.azavea.stac4s.extensions.layer.StacLayer
 
 class JvmSerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with Matchers with ArbitraryInstances {
   checkAll("Codec.ItemCollection", CodecTests[ItemCollection].unserializableCodec)
@@ -21,5 +22,6 @@ class JvmSerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers wit
   checkAll("Codec.StacCollection", CodecTests[StacCollection].unserializableCodec)
   checkAll("Codec.StacExtent", CodecTests[StacExtent].unserializableCodec)
   checkAll("Codec.TemporalExtent", CodecTests[TemporalExtent].unserializableCodec)
+  checkAll("Codec.StacLayer", CodecTests[StacLayer].unserializableCodec)
 
 }

--- a/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
+++ b/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
@@ -50,6 +50,7 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
 
   // Layer extension
   checkAll("Codec.LayerProperties", CodecTests[LayerItemExtension].unserializableCodec)
+  checkAll("Codec.StacLayerProperties", CodecTests[StacLayerProperties].unserializableCodec)
 
   // eo extension
   checkAll("Codec.EOBand", CodecTests[Band].unserializableCodec)

--- a/modules/core/js/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
+++ b/modules/core/js/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
@@ -1,12 +1,12 @@
 package com.azavea.stac4s.extensions.layer
 
 import com.azavea.stac4s.geometry.Geometry
-import eu.timepit.refined.types.string
 import com.azavea.stac4s.{Bbox, StacLink}
+
 import cats.kernel.Eq
-import io.circe.Encoder
+import eu.timepit.refined.types.string
 import io.circe.refined._
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 
 final case class StacLayer(
     id: string.NonEmptyString,

--- a/modules/core/js/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
+++ b/modules/core/js/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
@@ -1,0 +1,40 @@
+package com.azavea.stac4s.extensions.layer
+
+import com.azavea.stac4s.geometry.Geometry
+import eu.timepit.refined.types.string
+import com.azavea.stac4s.{Bbox, StacLink}
+import cats.kernel.Eq
+import io.circe.Encoder
+import io.circe.refined._
+import io.circe.Decoder
+
+final case class StacLayer(
+    id: string.NonEmptyString,
+    bbox: Bbox,
+    geometry: Geometry,
+    properties: StacLayerProperties,
+    links: List[StacLink],
+    _type: String = "Feature"
+)
+
+object StacLayer {
+  implicit val eqStacLayer: Eq[StacLayer] = Eq.fromUniversalEquals
+
+  implicit val encStacLayer: Encoder[StacLayer] = Encoder.forProduct6(
+    "id",
+    "bbox",
+    "geometry",
+    "properties",
+    "links",
+    "type"
+  )(layer => (layer.id, layer.bbox, layer.geometry, layer.properties, layer.links, layer._type))
+
+  implicit val decStacLayer: Decoder[StacLayer] = Decoder.forProduct6(
+    "id",
+    "bbox",
+    "geometry",
+    "properties",
+    "links",
+    "type"
+  )(StacLayer.apply)
+}

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
@@ -1,13 +1,13 @@
 package com.azavea.stac4s.extensions.layer
 
-import geotrellis.vector.Geometry
-import eu.timepit.refined.types.string
-import com.azavea.stac4s.{Bbox, StacLink}
 import com.azavea.stac4s.meta._
+import com.azavea.stac4s.{Bbox, StacLink}
+
 import cats.kernel.Eq
-import io.circe.Encoder
+import eu.timepit.refined.types.string
+import geotrellis.vector.Geometry
 import io.circe.refined._
-import io.circe.Decoder
+import io.circe.{Decoder, Encoder}
 
 final case class StacLayer(
     id: string.NonEmptyString,

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayer.scala
@@ -1,0 +1,41 @@
+package com.azavea.stac4s.extensions.layer
+
+import geotrellis.vector.Geometry
+import eu.timepit.refined.types.string
+import com.azavea.stac4s.{Bbox, StacLink}
+import com.azavea.stac4s.meta._
+import cats.kernel.Eq
+import io.circe.Encoder
+import io.circe.refined._
+import io.circe.Decoder
+
+final case class StacLayer(
+    id: string.NonEmptyString,
+    bbox: Bbox,
+    geometry: Geometry,
+    properties: StacLayerProperties,
+    links: List[StacLink],
+    _type: String = "Feature"
+)
+
+object StacLayer {
+  implicit val eqStacLayer: Eq[StacLayer] = Eq.fromUniversalEquals
+
+  implicit val encStacLayer: Encoder[StacLayer] = Encoder.forProduct6(
+    "id",
+    "bbox",
+    "geometry",
+    "properties",
+    "links",
+    "type"
+  )(layer => (layer.id, layer.bbox, layer.geometry, layer.properties, layer.links, layer._type))
+
+  implicit val decStacLayer: Decoder[StacLayer] = Decoder.forProduct6(
+    "id",
+    "bbox",
+    "geometry",
+    "properties",
+    "links",
+    "type"
+  )(StacLayer.apply)
+}

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayerProperties.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/layer/StacLayerProperties.scala
@@ -1,0 +1,26 @@
+package com.azavea.stac4s.extensions.layer
+
+import cats.kernel.Eq
+import io.circe.{Decoder, Encoder}
+
+import java.time.Instant
+
+final case class StacLayerProperties(
+    startDatetime: Instant,
+    endDatetime: Instant
+)
+
+object StacLayerProperties {
+
+  implicit val eqLayerProperties: Eq[StacLayerProperties] = Eq.fromUniversalEquals
+
+  implicit val decLayerProperties: Decoder[StacLayerProperties] = Decoder.forProduct2(
+    "start_datetime",
+    "end_datetime"
+  )(StacLayerProperties.apply)
+
+  implicit val encLayerProperties: Encoder[StacLayerProperties] = Encoder.forProduct2(
+    "start_datetime",
+    "end_datetime"
+  )(props => (props.startDatetime, props.endDatetime))
+}

--- a/modules/testing/js/src/main/scala/JsInstances.scala
+++ b/modules/testing/js/src/main/scala/JsInstances.scala
@@ -1,5 +1,6 @@
 package com.azavea.stac4s.testing
 
+import com.azavea.stac4s.extensions.layer.StacLayer
 import com.azavea.stac4s.geometry.Geometry.{MultiPolygon, Point2d, Polygon}
 import com.azavea.stac4s.geometry._
 import com.azavea.stac4s.types.TemporalExtent
@@ -25,7 +26,6 @@ import org.scalacheck.cats.implicits._
 import org.scalacheck.{Arbitrary, Gen}
 
 import java.time.Instant
-import com.azavea.stac4s.extensions.layer.StacLayer
 
 trait JsInstances {
 

--- a/modules/testing/js/src/main/scala/JsInstances.scala
+++ b/modules/testing/js/src/main/scala/JsInstances.scala
@@ -25,6 +25,7 @@ import org.scalacheck.cats.implicits._
 import org.scalacheck.{Arbitrary, Gen}
 
 import java.time.Instant
+import com.azavea.stac4s.extensions.layer.StacLayer
 
 trait JsInstances {
 
@@ -118,6 +119,17 @@ trait JsInstances {
       Gen.const(().asJsonObject)
     ).mapN(StacCollection.apply)
 
+  private[testing] def stacLayerGen: Gen[StacLayer] = (
+    nonEmptyAlphaRefinedStringGen,
+    TestInstances.bboxGen,
+    geometryGen,
+    TestInstances.stacLayerPropertiesGen,
+    Gen.listOfN(8, TestInstances.stacLinkGen),
+    Gen.const("Feature")
+  ).mapN(
+    StacLayer.apply
+  )
+
   implicit val arbItem: Arbitrary[StacItem] = Arbitrary { stacItemGen }
 
   val arbItemShort: Arbitrary[StacItem] = Arbitrary { stacItemShortGen }
@@ -133,6 +145,10 @@ trait JsInstances {
   implicit val arbGeometry: Arbitrary[Geometry] = Arbitrary { geometryGen }
 
   val arbCollectionShort: Arbitrary[StacCollection] = Arbitrary { stacCollectionShortGen }
+
+  implicit val arbStacLayer: Arbitrary[StacLayer] = Arbitrary {
+    stacLayerGen
+  }
 }
 
 object JsInstances extends JsInstances {}

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -1,5 +1,6 @@
 package com.azavea.stac4s.testing
 
+import com.azavea.stac4s.extensions.layer.StacLayer
 import com.azavea.stac4s.types.TemporalExtent
 import com.azavea.stac4s.{
   Bbox,
@@ -136,6 +137,17 @@ trait JvmInstances {
       Gen.const(().asJsonObject)
     ).mapN(StacCollection.apply)
 
+  private[testing] def stacLayerGen: Gen[StacLayer] = (
+    nonEmptyAlphaRefinedStringGen,
+    TestInstances.bboxGen,
+    rectangleGen,
+    TestInstances.stacLayerPropertiesGen,
+    Gen.listOfN(8, TestInstances.stacLinkGen),
+    Gen.const("Feature")
+  ).mapN(
+    StacLayer.apply
+  )
+
   implicit val arbItem: Arbitrary[StacItem] = Arbitrary { stacItemGen }
 
   val arbItemShort: Arbitrary[StacItem] = Arbitrary { stacItemShortGen }
@@ -164,6 +176,10 @@ trait JvmInstances {
 
   implicit val arbTemporalExtent: Arbitrary[TemporalExtent] = Arbitrary {
     temporalExtentGen
+  }
+
+  implicit val arbStaclayer: Arbitrary[StacLayer] = Arbitrary {
+    stacLayerGen
   }
 }
 

--- a/modules/testing/shared/src/main/scala/TestInstances.scala
+++ b/modules/testing/shared/src/main/scala/TestInstances.scala
@@ -5,7 +5,7 @@ import com.azavea.stac4s.extensions.asset._
 import com.azavea.stac4s.extensions.eo._
 import com.azavea.stac4s.extensions.label.LabelClassClasses._
 import com.azavea.stac4s.extensions.label._
-import com.azavea.stac4s.extensions.layer.LayerItemExtension
+import com.azavea.stac4s.extensions.layer.{LayerItemExtension, StacLayerProperties}
 
 import cats.syntax.apply._
 import cats.syntax.functor._
@@ -316,6 +316,16 @@ trait TestInstances extends NumericInstances {
       Gen.option(arbitrary[Percentage])
     ).mapN(EOItemExtension.apply)
 
+  private[testing] def stacLayerPropertiesGen: Gen[StacLayerProperties] =
+    (
+      instantGen,
+      instantGen
+    ).mapN {
+      case (inst1, inst2) if inst1.isBefore(inst2) =>
+        StacLayerProperties(inst1, inst2)
+      case (inst1, inst2) => StacLayerProperties(inst2, inst1)
+    }
+
   implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary {
     mediaTypeGen
   }
@@ -404,6 +414,10 @@ trait TestInstances extends NumericInstances {
 
   implicit val arbEOAssetExtension: Arbitrary[EOAssetExtension] = Arbitrary {
     eoAssetExtensionGen
+  }
+
+  implicit val arbStacLayerProperties: Arbitrary[StacLayerProperties] = Arbitrary {
+    stacLayerPropertiesGen
   }
 }
 


### PR DESCRIPTION
## Overview

This PR adds a `StacLayer` and `StacLayerProperties` type to support API extension work in Franklin.

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

### Notes

I opted to remove `stac_extensions` from these entities. Making them extensible makes layers overloadable for lots of purposes, which I think Maybe Bad :tm: -- getting rid of extensions and requiring the start and end datetime fields means that `StacLayers` can be used for one thing and one thing only, which I think is a good outcome. Pending review I'll make the same change in azavea/stac-layers

helps with geotrellis/geotrellis-server#316
