### PR TITLE
remove paradise compiler plugin, as it does not seem to be used

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,9 +20,6 @@ lazy val commonSettings = Seq(
   unusedCompileDependenciesFilter -= moduleFilter("com.sksamuel.scapegoat", "scalac-scapegoat-plugin"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.3" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
-  addCompilerPlugin(
-    "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
-  ),
   addCompilerPlugin(scalafixSemanticdb),
   autoCompilerPlugins := true,
   externalResolvers := Seq(


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

## Overview

The build includes the paradise macro compiler plugin, but there doesn't seem to be any code that uses it -- at least, removing still results in a successful build and test run. This requires a version-dependent switch for cross-compilation between 2.12 and 2.13. The plugin was added in commit 135006a with other changes intended to get publishing to Sonatype working, but seems unrelated. 

The motivation for this is to add support for cross-compilation against 2.13 for when geotrellis eventually has a 2.13 release available for vector, raster, and utils. 

### Checklist

- [ ] n/a New tests have been added or existing tests have been modified
- [ ] n/a (no code changes) Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

### Notes

none
