### PR TITLE
fix 2 compile issues with 2.13 -- nowarn and non-exhausive match

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -131,16 +131,16 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(publishSettings)
   .settings({
     libraryDependencies ++= Seq(
-      "com.beachape"  %%% "enumeratum"       % Versions.Enumeratum,
-      "com.beachape"  %%% "enumeratum-circe" % Versions.Enumeratum,
-      "com.chuusai"   %%% "shapeless"        % Versions.Shapeless,
-      "eu.timepit"    %%% "refined"          % Versions.Refined,
-      "io.circe"      %%% "circe-core"       % Versions.Circe,
-      "io.circe"      %%% "circe-generic"    % Versions.Circe,
-      "io.circe"      %%% "circe-parser"     % Versions.Circe,
-      "io.circe"      %%% "circe-refined"    % Versions.Circe,
-      "org.typelevel" %%% "cats-core"        % Versions.Cats,
-      "org.typelevel" %%% "cats-kernel"      % Versions.Cats,
+      "com.beachape"          %%% "enumeratum"              % Versions.Enumeratum,
+      "com.beachape"          %%% "enumeratum-circe"        % Versions.Enumeratum,
+      "com.chuusai"           %%% "shapeless"               % Versions.Shapeless,
+      "eu.timepit"            %%% "refined"                 % Versions.Refined,
+      "io.circe"              %%% "circe-core"              % Versions.Circe,
+      "io.circe"              %%% "circe-generic"           % Versions.Circe,
+      "io.circe"              %%% "circe-parser"            % Versions.Circe,
+      "io.circe"              %%% "circe-refined"           % Versions.Circe,
+      "org.typelevel"         %%% "cats-core"               % Versions.Cats,
+      "org.typelevel"         %%% "cats-kernel"             % Versions.Cats,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
     )
   })

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,9 @@ lazy val commonSettings = Seq(
   scalafmtOnCompile := true,
   scapegoatVersion in ThisBuild := Versions.Scapegoat,
   scapegoatDisabledInspections := Seq("ObjectNames", "EmptyCaseClass"),
-  unusedCompileDependenciesFilter -= moduleFilter("com.sksamuel.scapegoat", "scalac-scapegoat-plugin"),
+  unusedCompileDependenciesFilter -=
+    moduleFilter("com.sksamuel.scapegoat", "scalac-scapegoat-plugin") |
+    moduleFilter("org.scala-lang.modules", "scala-collection-compat"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.3" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
   addCompilerPlugin(scalafixSemanticdb),
@@ -141,7 +143,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "io.circe"              %%% "circe-refined"           % Versions.Circe,
       "org.typelevel"         %%% "cats-core"               % Versions.Cats,
       "org.typelevel"         %%% "cats-kernel"             % Versions.Cats,
-      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2" % Compile
     )
   })
   .jvmSettings(libraryDependencies ++= coreDependenciesJVM)

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val commonSettings = Seq(
   scapegoatDisabledInspections := Seq("ObjectNames", "EmptyCaseClass"),
   unusedCompileDependenciesFilter -=
     moduleFilter("com.sksamuel.scapegoat", "scalac-scapegoat-plugin") |
-    moduleFilter("org.scala-lang.modules", "scala-collection-compat"),
+      moduleFilter("org.scala-lang.modules", "scala-collection-compat"),
   addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.3" cross CrossVersion.full),
   addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1"),
   addCompilerPlugin(scalafixSemanticdb),

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ lazy val commonSettings = Seq(
       git.gitDescribedVersion.value.get
   },
   scalaVersion := "2.12.13",
+  crossScalaVersions := List("2.12.13"),
   cancelable in Global := true,
   scalafmtOnCompile := true,
   scapegoatVersion in ThisBuild := Versions.Scapegoat,
@@ -139,7 +140,8 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "io.circe"      %%% "circe-parser"     % Versions.Circe,
       "io.circe"      %%% "circe-refined"    % Versions.Circe,
       "org.typelevel" %%% "cats-core"        % Versions.Cats,
-      "org.typelevel" %%% "cats-kernel"      % Versions.Cats
+      "org.typelevel" %%% "cats-kernel"      % Versions.Cats,
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.4.2"
     )
   })
   .jvmSettings(libraryDependencies ++= coreDependenciesJVM)

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
@@ -21,6 +21,7 @@ trait ClientCodecs {
       case Some(start) :: Some(end) :: _ if start == end => s"${start.toString}"
       case Some(start) :: None :: _                      => s"${start.toString}/.."
       case None :: Some(end) :: _                        => s"../${end.toString}"
+      case x                                             => throw new scala.MatchError(x)
     }
 
   private def temporalExtentFromString(str: String): Either[String, TemporalExtent] = {

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/ProductFieldNames.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/ProductFieldNames.scala
@@ -4,6 +4,8 @@ import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 import shapeless.{HList, LabelledGeneric}
 
+import scala.annotation.nowarn
+
 trait ProductFieldNames[T] {
   def get: Set[String]
 }
@@ -11,6 +13,7 @@ trait ProductFieldNames[T] {
 object ProductFieldNames {
   def apply[T](implicit ev: ProductFieldNames[T]): ProductFieldNames[T] = ev
 
+  @nowarn // parameter value evidence$1 in method fromLabelledGeneric is never used
   @SuppressWarnings(Array("all"))
   implicit def fromLabelledGeneric[T: LabelledGeneric.Aux[*, L], L <: HList, K <: HList](implicit
       keys: Keys.Aux[L, K],


### PR DESCRIPTION
Signed-off-by: philvarner <philvarner@gmail.com>

## Overview

Fixes the only two issues when compiling against 2.13 (using a local version of geotrellis libs that have been compiled against 2.13)  

Works towards #77 

1. non-exhaustive pattern match is an error (or a warning that the build is configured to handle as an error? I can't remember right now).  This preserves the existing behavior for invalidly constructed TemporalExtents, which is probably fine, since all the instances that can be created with the apply methods are handled.
2. add `@nowarn` annotation on a false-positive warning

### Checklist

- [ ] n/a New tests have been added or existing tests have been modified
- [ ] **no behavior changes** Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

### Notes

none
