### PR TITLE
Test bbox laws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Tested bbox union invariants [#266](https://github.com/azavea/stac4s/pull/266)
 
 ## [0.1.1] - 2021-03-12
 ### Fixed

--- a/modules/core-test/shared/src/test/scala/com/azavea/stac4s/BboxSpec.scala
+++ b/modules/core-test/shared/src/test/scala/com/azavea/stac4s/BboxSpec.scala
@@ -1,0 +1,32 @@
+package com.azavea.stac4s
+
+import com.azavea.stac4s.testing.TestInstances._
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+
+class BboxSpec extends AnyFunSuite with Checkers with Matchers {
+
+  test("union with left consituent and union is union") {
+    check { (bbox1: Bbox, bbox2: Bbox) =>
+      bbox1.union(bbox2).union(bbox1) == bbox1.union(bbox2)
+    }
+  }
+
+  test("union with right constituent and union is union") {
+    check { (bbox1: Bbox, bbox2: Bbox) =>
+      bbox1.union(bbox2).union(bbox2) == bbox1.union(bbox2)
+    }
+  }
+
+  test("union with self is union") {
+    check { (bbox1: Bbox, bbox2: Bbox) =>
+      {
+        val unioned = bbox1.union(bbox2)
+        unioned.union(unioned) == unioned
+      }
+    }
+  }
+
+}

--- a/modules/testing/shared/src/main/scala/TestInstances.scala
+++ b/modules/testing/shared/src/main/scala/TestInstances.scala
@@ -120,8 +120,8 @@ trait TestInstances extends NumericInstances {
       lowerY <- finiteDoubleGen
     } yield {
       TwoDimBbox(
-        lowerX,
-        lowerY,
+        lowerX.round.toDouble,
+        lowerY.round.toDouble,
         lowerX + 100,
         lowerY + 100
       )

--- a/modules/testing/shared/src/main/scala/TestInstances.scala
+++ b/modules/testing/shared/src/main/scala/TestInstances.scala
@@ -120,8 +120,8 @@ trait TestInstances extends NumericInstances {
       lowerY <- finiteDoubleGen
     } yield {
       TwoDimBbox(
-        lowerX.round.toDouble,
-        lowerY.round.toDouble,
+        lowerX,
+        lowerY,
         lowerX + 100,
         lowerY + 100
       )


### PR DESCRIPTION
## Overview

I'm calling these tests "bbox laws." I added these to deal with some downstream test failures that I wasn't expecting in azavea/franklin#623. It turns out the bbox union isn't the problem, but it's still useful to include these tests

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
