### PR TITLE
Model periodic intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Added
 - Tested bbox union invariants [#266](https://github.com/azavea/stac4s/pull/266)
+- Modeled periodic extent and made intervals extensible [#276](https://github.com/azavea/stac4s/pull/276)
 
 ## [0.1.1] - 2021-03-12
 ### Fixed

--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,8 @@ val coreDependenciesJVM = Seq(
 
 val testingDependenciesJVM = Seq(
   "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis,
-  "org.locationtech.jts"         % "jts-core"          % Versions.Jts
+  "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
+  "org.threeten"                 % "threeten-extra"    % Versions.ThreeTenExtra
 )
 
 val testRunnerDependenciesJVM = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,8 @@ lazy val credentialSettings = Seq(
 
 val coreDependenciesJVM = Seq(
   "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
-  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis
+  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis,
+  "org.threeten"                 % "threeten-extra"    % Versions.ThreeTenExtra
 )
 
 val testingDependenciesJVM = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -100,11 +100,14 @@ lazy val credentialSettings = Seq(
   ).flatten
 )
 
-val coreDependenciesJVM = Seq(
+val jvmGeometryDependencies = Seq(
   "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
-  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis,
-  "org.threeten"                 % "threeten-extra"    % Versions.ThreeTenExtra
+  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis
 )
+
+val coreDependenciesJVM = Seq(
+  "org.threeten" % "threeten-extra" % Versions.ThreeTenExtra
+) ++ jvmGeometryDependencies
 
 val testingDependenciesJVM = Seq(
   "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis,
@@ -223,7 +226,7 @@ lazy val client = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.2.1")
-  .jvmSettings(libraryDependencies ++= coreDependenciesJVM)
+  .jvmSettings(libraryDependencies ++= jvmGeometryDependencies)
 
 lazy val clientJVM = client.jvm
 lazy val clientJS  = client.js

--- a/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
+++ b/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
@@ -13,6 +13,8 @@ import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 import java.time.Instant
 import com.azavea.stac4s.extensions.layer.StacLayer
+import org.threeten.extra.PeriodDuration
+import com.azavea.stac4s.extensions.periodic.PeriodicExtent
 
 class JvmSerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with Matchers with ArbitraryInstances {
   checkAll("Codec.ItemCollection", CodecTests[ItemCollection].unserializableCodec)
@@ -23,4 +25,6 @@ class JvmSerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers wit
   checkAll("Codec.StacExtent", CodecTests[StacExtent].unserializableCodec)
   checkAll("Codec.TemporalExtent", CodecTests[TemporalExtent].unserializableCodec)
   checkAll("Codec.StacLayer", CodecTests[StacLayer].unserializableCodec)
+  checkAll("Codec.PeriodDuration", CodecTests[PeriodDuration].unserializableCodec)
+  checkAll("Codec.PeriodicExtent", CodecTests[PeriodicExtent].unserializableCodec)
 }

--- a/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
+++ b/modules/core-test/jvm/src/test/scala/com/azavea/stac4s/JvmSerDeSpec.scala
@@ -22,6 +22,7 @@ class JvmSerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers wit
   checkAll("Codec.Geometry", CodecTests[Geometry].unserializableCodec)
   checkAll("Codec.Instant", CodecTests[Instant].unserializableCodec)
   checkAll("Codec.StacCollection", CodecTests[StacCollection].unserializableCodec)
+  checkAll("Codec.Interval", CodecTests[Interval].unserializableCodec)
   checkAll("Codec.StacExtent", CodecTests[StacExtent].unserializableCodec)
   checkAll("Codec.TemporalExtent", CodecTests[TemporalExtent].unserializableCodec)
   checkAll("Codec.StacLayer", CodecTests[StacLayer].unserializableCodec)

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacExtent.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacExtent.scala
@@ -3,9 +3,11 @@ package com.azavea.stac4s
 import com.azavea.stac4s.types._
 
 import cats.Eq
+import cats.syntax.apply._
 import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.refined._
+import io.circe.syntax._
 
 final case class SpatialExtent(bbox: List[Bbox])
 
@@ -14,11 +16,34 @@ object SpatialExtent {
   implicit val decSpatialExtent: Decoder[SpatialExtent] = deriveDecoder
 }
 
-final case class Interval(interval: List[TemporalExtent])
+final case class Interval(interval: List[TemporalExtent], extensionFields: JsonObject = JsonObject.empty)
 
 object Interval {
-  implicit val encInterval: Encoder[Interval] = deriveEncoder
-  implicit val decInterval: Decoder[Interval] = deriveDecoder
+  val intervalFields = productFieldNames[Interval]
+
+  implicit val encInterval: Encoder[Interval] = { interval: Interval =>
+    val baseEncInterval: Encoder[Interval] = Encoder.forProduct1("interval")({ interval: Interval =>
+      interval.interval
+    })
+    baseEncInterval(interval).deepMerge(interval.extensionFields.asJson)
+  }
+
+  implicit val decInterval: Decoder[Interval] = { c: HCursor =>
+    (
+      c.get[List[TemporalExtent]]("interval"),
+      c.value.as[JsonObject]
+    ) mapN { (interval: List[TemporalExtent], document: JsonObject) =>
+      Interval(
+        interval,
+        document.filter({ case (k, _) =>
+          !intervalFields.contains(k)
+        })
+      )
+    }
+
+  }
+
+  implicit val eqInterval: Eq[Interval] = Eq.fromUniversalEquals
 }
 
 final case class StacExtent(

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/IntervalExtension.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/IntervalExtension.scala
@@ -1,9 +1,9 @@
 package com.azavea.stac4s.extensions
 
 import com.azavea.stac4s.Interval
-import io.circe.Decoder
-import io.circe.Encoder
+
 import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
 
 trait IntervalExtension[T] {
   def getExtensionFields(interval: Interval): ExtensionResult[T]

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/IntervalExtension.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/IntervalExtension.scala
@@ -1,0 +1,25 @@
+package com.azavea.stac4s.extensions
+
+import com.azavea.stac4s.Interval
+import io.circe.Decoder
+import io.circe.Encoder
+import io.circe.syntax._
+
+trait IntervalExtension[T] {
+  def getExtensionFields(interval: Interval): ExtensionResult[T]
+  def addExtensionFields(interval: Interval, extensionFields: T): Interval
+}
+
+object IntervalExtension {
+  def apply[T](implicit ev: IntervalExtension[T]): IntervalExtension[T] = ev
+
+  def instance[T](implicit decoder: Decoder[T], objectEncoder: Encoder.AsObject[T]) =
+    new IntervalExtension[T] {
+
+      def getExtensionFields(interval: Interval): ExtensionResult[T] =
+        decoder.decodeAccumulating(interval.extensionFields.asJson.hcursor)
+
+      def addExtensionFields(interval: Interval, extensionFields: T): Interval =
+        interval.copy(extensionFields = interval.extensionFields.deepMerge(objectEncoder.encodeObject(extensionFields)))
+    }
+}

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
@@ -1,10 +1,19 @@
 package com.azavea.stac4s.extensions.periodic
 
-import com.azavea.stac4s.Interval
+import com.azavea.stac4s.meta._
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import org.threeten.extra.PeriodDuration
+import io.circe.Decoder
+import io.circe.Encoder
+import cats.kernel.Eq
 
 final case class PeriodicExtent(
-    range: Interval,
     period: PeriodDuration
 )
+
+object PeriodicExtent {
+  implicit val decPeriodicExtent: Decoder[PeriodicExtent] = deriveDecoder
+  implicit val encPeriodicExtent: Encoder[PeriodicExtent] = deriveEncoder
+  implicit val eqPeriodicExtent: Eq[PeriodicExtent]       = Eq.fromUniversalEquals
+}

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
@@ -7,13 +7,16 @@ import org.threeten.extra.PeriodDuration
 import io.circe.Decoder
 import io.circe.Encoder
 import cats.kernel.Eq
+import com.azavea.stac4s.extensions.IntervalExtension
 
 final case class PeriodicExtent(
     period: PeriodDuration
 )
 
 object PeriodicExtent {
-  implicit val decPeriodicExtent: Decoder[PeriodicExtent] = deriveDecoder
-  implicit val encPeriodicExtent: Encoder[PeriodicExtent] = deriveEncoder
-  implicit val eqPeriodicExtent: Eq[PeriodicExtent]       = Eq.fromUniversalEquals
+  implicit val decPeriodicExtent: Decoder[PeriodicExtent]                = deriveDecoder
+  implicit val encPeriodicExtentObject: Encoder.AsObject[PeriodicExtent] = deriveEncoder
+  implicit val eqPeriodicExtent: Eq[PeriodicExtent]                      = Eq.fromUniversalEquals
+
+  implicit val intervalExtension: IntervalExtension[PeriodicExtent] = IntervalExtension.instance[PeriodicExtent]
 }

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
@@ -1,13 +1,12 @@
 package com.azavea.stac4s.extensions.periodic
 
+import com.azavea.stac4s.extensions.IntervalExtension
 import com.azavea.stac4s.meta._
 
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import org.threeten.extra.PeriodDuration
-import io.circe.Decoder
-import io.circe.Encoder
 import cats.kernel.Eq
-import com.azavea.stac4s.extensions.IntervalExtension
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
+import org.threeten.extra.PeriodDuration
 
 final case class PeriodicExtent(
     period: PeriodDuration

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/extensions/periodic/PeriodicExtent.scala
@@ -1,0 +1,10 @@
+package com.azavea.stac4s.extensions.periodic
+
+import com.azavea.stac4s.Interval
+
+import org.threeten.extra.PeriodDuration
+
+final case class PeriodicExtent(
+    range: Interval,
+    period: PeriodDuration
+)

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
@@ -13,6 +13,7 @@ import scala.util.Try
 
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.{Instant, OffsetDateTime}
+import org.threeten.extra.PeriodDuration
 
 trait ForeignImplicits {
 
@@ -67,6 +68,13 @@ trait ForeignImplicits {
         throw new ParsingFailure(message, new Exception(message))
     }
   }
+
+  implicit val decPeriodDuration: Decoder[PeriodDuration] =
+    Decoder[String].emap(s =>
+      Either.fromTry(Try(PeriodDuration.parse(s))).leftMap(_ => s"$s was not a valid period duration format")
+    )
+  implicit val encPeriodDuration: Encoder[PeriodDuration] = Encoder[String].contramap(_.toString)
+  implicit val eqPeriodDuration: Eq[PeriodDuration]       = Eq.fromUniversalEquals
 
 }
 

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
@@ -8,12 +8,12 @@ import eu.timepit.refined.api.RefType
 import io.circe._
 import io.circe.parser.decode
 import io.circe.syntax._
+import org.threeten.extra.PeriodDuration
 
 import scala.util.Try
 
 import java.time.format.{DateTimeFormatter, DateTimeFormatterBuilder}
 import java.time.{Instant, OffsetDateTime}
-import org.threeten.extra.PeriodDuration
 
 trait ForeignImplicits {
 

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/syntax/package.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/syntax/package.scala
@@ -13,4 +13,13 @@ package object syntax extends Syntax {
       ev.addExtensionFields(collection, properties)
   }
 
+  implicit class intervalExtensions(interval: Interval) {
+
+    def getExtensionFields[T](implicit ev: IntervalExtension[T]): ExtensionResult[T] =
+      ev.getExtensionFields(interval)
+
+    def addExtensionFields[T](properties: T)(implicit ev: IntervalExtension[T]): Interval =
+      ev.addExtensionFields(interval, properties)
+  }
+
 }

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -29,6 +29,7 @@ import org.threeten.extra.PeriodDuration
 import java.time.Period
 import java.time.Duration
 import com.azavea.stac4s.extensions.periodic.PeriodicExtent
+import com.azavea.stac4s.syntax._
 
 trait JvmInstances {
 
@@ -38,6 +39,14 @@ trait JvmInstances {
         TemporalExtent(start, end)
       }
   }
+
+  private[testing] def intervalGen: Gen[Interval] =
+    (periodicExtentGen, temporalExtentGen).tupled flatMap { case (periodicity, temporalExtent) =>
+      Gen.oneOf(
+        Gen.const(Interval(List(temporalExtent))),
+        Gen.const(Interval(List(temporalExtent)).addExtensionFields(periodicity))
+      )
+    }
 
   private[testing] def rectangleGen: Gen[Geometry] =
     (for {
@@ -211,6 +220,10 @@ trait JvmInstances {
 
   implicit val arbPeriodicExtent: Arbitrary[PeriodicExtent] = Arbitrary {
     periodicExtentGen
+  }
+
+  implicit val arbInterval: Arbitrary[Interval] = Arbitrary {
+    intervalGen
   }
 }
 

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -1,6 +1,8 @@
 package com.azavea.stac4s.testing
 
 import com.azavea.stac4s.extensions.layer.StacLayer
+import com.azavea.stac4s.extensions.periodic.PeriodicExtent
+import com.azavea.stac4s.syntax._
 import com.azavea.stac4s.types.TemporalExtent
 import com.azavea.stac4s.{
   Bbox,
@@ -23,13 +25,9 @@ import io.circe.syntax._
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.cats.implicits._
 import org.scalacheck.{Arbitrary, Gen}
-
-import java.time.Instant
 import org.threeten.extra.PeriodDuration
-import java.time.Period
-import java.time.Duration
-import com.azavea.stac4s.extensions.periodic.PeriodicExtent
-import com.azavea.stac4s.syntax._
+
+import java.time.{Duration, Instant, Period}
 
 trait JvmInstances {
 

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -25,6 +25,10 @@ import org.scalacheck.cats.implicits._
 import org.scalacheck.{Arbitrary, Gen}
 
 import java.time.Instant
+import org.threeten.extra.PeriodDuration
+import java.time.Period
+import java.time.Duration
+import com.azavea.stac4s.extensions.periodic.PeriodicExtent
 
 trait JvmInstances {
 
@@ -148,6 +152,25 @@ trait JvmInstances {
     StacLayer.apply
   )
 
+  private[testing] def periodDurationGen: Gen[PeriodDuration] = for {
+    years  <- Gen.choose(0, 100)
+    months <- Gen.choose(0, 12)
+    days   <- Gen.choose(0, 100)
+    // minutes is an Int because with a Long we overflow during the test.
+    // since Long.MaxValue is a suuuuuuuper unlikely quantity of minutes in a
+    // duration, I'm declaring this More or Less Fine™
+    minutes <- arbitrary[Int]
+  } yield PeriodDuration.of(
+    Period.of(years, months, days),
+    Duration.ofMinutes(minutes.toLong)
+  )
+
+  private[testing] def periodicExtentGen: Gen[PeriodicExtent] = (
+    periodDurationGen
+  ) map {
+    PeriodicExtent.apply
+  }
+
   implicit val arbItem: Arbitrary[StacItem] = Arbitrary { stacItemGen }
 
   val arbItemShort: Arbitrary[StacItem] = Arbitrary { stacItemShortGen }
@@ -180,6 +203,14 @@ trait JvmInstances {
 
   implicit val arbStaclayer: Arbitrary[StacLayer] = Arbitrary {
     stacLayerGen
+  }
+
+  implicit val arbPeriodDuration: Arbitrary[PeriodDuration] = Arbitrary {
+    periodDurationGen
+  }
+
+  implicit val arbPeriodicExtent: Arbitrary[PeriodicExtent] = Arbitrary {
+    periodicExtentGen
   }
 }
 

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -15,4 +15,5 @@ object Versions {
   val Sttp                    = "3.1.7"
   val SttpModel               = "1.3.3"
   val SttpShared              = "1.1.1"
+  val ThreeTenExtra           = "1.6.0"
 }


### PR DESCRIPTION
## Overview

This PR:

- makes `Intervals` extensible with the `InteralExtension` typeclass
- models the periodic extension to intervals with the `PeriodicExtent` type
- adds tests for all this stuff

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

### Notes

I skipped JS. This extension is experimental, and as much fun as simple time types were, I was not super interested in more complicated time types. If we get good use out of this extension and discover we need it in js, we can add it then.

Closes #268
