### PR TITLE
Bound asset map generators

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ aliases:
     - run:
         name: Executing cibuild
         command: ./scripts/test
+    - store_test_results:
+        path: modules/core-test/jvm/target/test-reports
+    - store_test_results:
+        path: modules/core-test/js/target/test-reports
     - save_cache:
         key: sbt-cache-{{ checksum "project/Versions.scala" }}
         paths:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Bounded generators to prevent downstream test speed and memory issues [#290](https://github.com/azavea/stac4s/pull/290)
 
 ## [0.2.0] - 2021-04-19
 ### Added

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/meta/ValidStacVersion.scala
@@ -7,7 +7,7 @@ final case class ValidStacVersion()
 object ValidStacVersion {
 
   val stacVersions = List(
-    "1.0.0-beta.2"
+    "1.0.0-rc2"
   )
 
   implicit def validStacVersion: Validate.Plain[String, ValidStacVersion] =

--- a/modules/testing/js/src/main/scala/JsInstances.scala
+++ b/modules/testing/js/src/main/scala/JsInstances.scala
@@ -60,13 +60,13 @@ trait JsInstances extends GenericInstances {
   private[testing] def stacItemGen: Gen[StacItem] =
     (
       nonEmptyStringGen,
-      Gen.const("0.8.0"),
+      Gen.const("1.0.0-rc2"),
       Gen.const(List.empty[String]),
       Gen.const("Feature"),
       geometryGen,
       TestInstances.twoDimBboxGen,
       nonEmptyListGen(TestInstances.stacLinkGen) map { _.toList },
-      Gen.nonEmptyMap((nonEmptyStringGen, TestInstances.cogAssetGen).tupled),
+      TestInstances.assetMapGen,
       Gen.option(nonEmptyStringGen),
       TestInstances.itemExtensionFieldsGen
     ).mapN(StacItem.apply)
@@ -74,7 +74,7 @@ trait JsInstances extends GenericInstances {
   private[testing] def stacItemShortGen: Gen[StacItem] =
     (
       nonEmptyStringGen,
-      Gen.const("0.8.0"),
+      Gen.const("1.0.0-rc2"),
       Gen.const(List.empty[String]),
       Gen.const("Feature"),
       geometryGen,
@@ -88,7 +88,7 @@ trait JsInstances extends GenericInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-rc2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -98,7 +98,7 @@ trait JsInstances extends GenericInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-rc2")),
       Gen.const(Nil),
       Gen.listOfN[StacItem](2, stacItemGen),
       Gen.const(Nil),
@@ -108,7 +108,7 @@ trait JsInstances extends GenericInstances {
   private[testing] def stacCollectionShortGen: Gen[StacCollection] =
     (
       Arbitrary.arbitrary[CollectionType],
-      Gen.const("1.0.0-beta.2"),
+      Gen.const("1.0.0-rc2"),
       Gen.const(Nil),
       nonEmptyStringGen,
       nonEmptyStringGen.map(_.some),
@@ -120,7 +120,7 @@ trait JsInstances extends GenericInstances {
       Gen.const(JsonObject.empty),
       Gen.const(JsonObject.empty),
       Gen.const(Nil),
-      Gen.option(Gen.nonEmptyMap((nonEmptyStringGen, TestInstances.cogAssetGen).tupled)),
+      Gen.option(TestInstances.assetMapGen),
       Gen.const(().asJsonObject)
     ).mapN(StacCollection.apply)
 

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -63,13 +63,13 @@ trait JvmInstances {
   private[testing] def stacItemGen: Gen[StacItem] =
     (
       nonEmptyStringGen,
-      Gen.const("0.8.0"),
+      Gen.const("1.0.0-rc2"),
       Gen.const(List.empty[String]),
       Gen.const("Feature"),
       rectangleGen,
       TestInstances.twoDimBboxGen,
       nonEmptyListGen(TestInstances.stacLinkGen) map { _.toList },
-      Gen.nonEmptyMap((nonEmptyStringGen, TestInstances.cogAssetGen).tupled),
+      TestInstances.assetMapGen,
       Gen.option(nonEmptyStringGen),
       TestInstances.itemExtensionFieldsGen
     ).mapN(StacItem.apply)
@@ -77,7 +77,7 @@ trait JvmInstances {
   private[testing] def stacItemShortGen: Gen[StacItem] =
     (
       nonEmptyStringGen,
-      Gen.const("0.8.0"),
+      Gen.const("1.0.0-rc2"),
       Gen.const(List.empty[String]),
       Gen.const("Feature"),
       rectangleGen,
@@ -91,7 +91,7 @@ trait JvmInstances {
   private[testing] def itemCollectionGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-rc2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.listOf[StacLink](TestInstances.stacLinkGen),
@@ -101,7 +101,7 @@ trait JvmInstances {
   private[testing] def itemCollectionShortGen: Gen[ItemCollection] =
     (
       Gen.const("FeatureCollection"),
-      Gen.const(StacVersion.unsafeFrom("1.0.0-beta.2")),
+      Gen.const(StacVersion.unsafeFrom("1.0.0-rc2")),
       Gen.const(Nil),
       Gen.listOf[StacItem](stacItemGen),
       Gen.const(Nil),
@@ -128,7 +128,7 @@ trait JvmInstances {
       Gen.const(().asJsonObject),
       Gen.const(JsonObject.fromMap(Map.empty)),
       possiblyEmptyListGen(TestInstances.stacLinkGen),
-      Gen.option(Gen.nonEmptyMap((nonEmptyStringGen, TestInstances.cogAssetGen).tupled)),
+      Gen.option(TestInstances.assetMapGen),
       TestInstances.collectionExtensionFieldsGen
     ).mapN(StacCollection.apply)
 

--- a/modules/testing/shared/src/main/scala/TestInstances.scala
+++ b/modules/testing/shared/src/main/scala/TestInstances.scala
@@ -324,6 +324,12 @@ trait TestInstances extends NumericInstances with GenericInstances {
       case (inst1, inst2) => StacLayerProperties(inst2, inst1)
     }
 
+  private[testing] def assetMapGen: Gen[Map[String, StacAsset]] =
+    Gen.oneOf(
+      Gen.const(Map.empty),
+      Gen.listOfN(5, (nonEmptyAlphaRefinedStringGen, cogAssetGen).tupled)
+    )
+
   implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary {
     mediaTypeGen
   }

--- a/modules/testing/shared/src/main/scala/TestInstances.scala
+++ b/modules/testing/shared/src/main/scala/TestInstances.scala
@@ -326,8 +326,8 @@ trait TestInstances extends NumericInstances with GenericInstances {
 
   private[testing] def assetMapGen: Gen[Map[String, StacAsset]] =
     Gen.oneOf(
-      Gen.const(Map.empty),
-      Gen.listOfN(5, (nonEmptyAlphaRefinedStringGen, cogAssetGen).tupled)
+      Gen.const(Map.empty[String, StacAsset]),
+      Gen.listOfN(5, (nonEmptyStringGen, cogAssetGen).tupled) map { Map(_: _*) }
     )
 
   implicit val arbMediaType: Arbitrary[StacMediaType] = Arbitrary {


### PR DESCRIPTION
## Overview

This PR bounds the asset map generators for items and collections so they don't consume hilarious amounts of memory and break downstream tests.

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

### Notes

Tested with local publication and Franklin where the problem was occurring. Will merge / release post-CI.

Closes #289 
