### PR TITLE
Decode collection type field in JVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- JVM StacCollections also have a type [#299](https://github.com/azavea/stac4s/pull/299)
 
 ## [0.2.1] - 2021-04-20
 ### Fixed

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacCollection.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacCollection.scala
@@ -1,11 +1,15 @@
 package com.azavea.stac4s
 
+import com.azavea.stac4s.types.CollectionType
+
 import cats.Eq
 import cats.syntax.apply._
 import io.circe._
+import io.circe.refined._
 import io.circe.syntax._
 
 final case class StacCollection(
+    _type: CollectionType,
     stacVersion: String,
     stacExtensions: List[String],
     id: String,
@@ -28,7 +32,8 @@ object StacCollection {
   implicit val eqStacCollection: Eq[StacCollection] = Eq.fromUniversalEquals
 
   implicit val encoderStacCollection: Encoder[StacCollection] = { collection =>
-    val baseEncoder: Encoder[StacCollection] = Encoder.forProduct13(
+    val baseEncoder: Encoder[StacCollection] = Encoder.forProduct14(
+      "type",
       "stac_version",
       "stac_extensions",
       "id",
@@ -44,6 +49,7 @@ object StacCollection {
       "assets"
     )(collection =>
       (
+        collection._type,
         collection.stacVersion,
         collection.stacExtensions,
         collection.id,
@@ -65,6 +71,7 @@ object StacCollection {
 
   implicit val decoderStacCollection: Decoder[StacCollection] = { c: HCursor =>
     (
+      c.get[CollectionType]("type"),
       c.get[String]("stac_version"),
       c.get[Option[List[String]]]("stac_extensions"),
       c.get[String]("id"),
@@ -81,6 +88,7 @@ object StacCollection {
       c.value.as[JsonObject]
     ).mapN(
       (
+          _type: CollectionType,
           stacVersion: String,
           stacExtensions: Option[List[String]],
           id: String,
@@ -97,6 +105,7 @@ object StacCollection {
           extensionFields: JsonObject
       ) =>
         StacCollection(
+          _type,
           stacVersion,
           stacExtensions getOrElse Nil,
           id,

--- a/modules/testing/jvm/src/main/scala/JvmInstances.scala
+++ b/modules/testing/jvm/src/main/scala/JvmInstances.scala
@@ -4,6 +4,7 @@ import com.azavea.stac4s.extensions.layer.StacLayer
 import com.azavea.stac4s.extensions.periodic.PeriodicExtent
 import com.azavea.stac4s.jvmTypes.TemporalExtent
 import com.azavea.stac4s.syntax._
+import com.azavea.stac4s.types.CollectionType
 import com.azavea.stac4s.{
   Bbox,
   Interval,
@@ -19,6 +20,7 @@ import com.azavea.stac4s.{
 
 import cats.syntax.apply._
 import cats.syntax.functor._
+import eu.timepit.refined.scalacheck.GenericInstances
 import geotrellis.vector.{Geometry, Point, Polygon}
 import io.circe.JsonObject
 import io.circe.syntax._
@@ -29,7 +31,7 @@ import org.threeten.extra.PeriodDuration
 
 import java.time.{Duration, Instant, Period}
 
-trait JvmInstances {
+trait JvmInstances extends GenericInstances {
 
   private[testing] def temporalExtentGen: Gen[TemporalExtent] = {
     (arbitrary[Instant], arbitrary[Instant]).tupled
@@ -116,6 +118,7 @@ trait JvmInstances {
 
   private[testing] def stacCollectionGen: Gen[StacCollection] =
     (
+      Arbitrary.arbitrary[CollectionType],
       nonEmptyStringGen,
       possiblyEmptyListGen(nonEmptyStringGen),
       nonEmptyStringGen,
@@ -134,6 +137,7 @@ trait JvmInstances {
 
   private[testing] def stacCollectionShortGen: Gen[StacCollection] =
     (
+      Arbitrary.arbitrary[CollectionType],
       nonEmptyStringGen,
       possiblyEmptyListGen(nonEmptyStringGen),
       nonEmptyStringGen,


### PR DESCRIPTION
## Overview

This PR corrects an omission where the JVM `StacCollection` `_type` field was missing. This adds the field, decodes it, and adds it to generators.

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
