### PR TITLE
Selectively drop nulls in encoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Encoders make deliberate choices about dropping or not dropping nulls [#302](https://github.com/azavea/stac4s/pull/302)
 
 ## [0.2.2] - 2021-04-28
 ### Fixed

--- a/modules/core/js/src/main/scala/com/azavea/stac4s/StacCollection.scala
+++ b/modules/core/js/src/main/scala/com/azavea/stac4s/StacCollection.scala
@@ -66,7 +66,7 @@ object StacCollection {
       )
     )
 
-    baseEncoder(collection).deepMerge(collection.extensionFields.asJson)
+    baseEncoder(collection).deepMerge(collection.extensionFields.asJson).dropNullValues
   }
 
   implicit val decoderStacCollection: Decoder[StacCollection] = { c: HCursor =>

--- a/modules/core/js/src/main/scala/com/azavea/stac4s/StacItem.scala
+++ b/modules/core/js/src/main/scala/com/azavea/stac4s/StacItem.scala
@@ -28,31 +28,33 @@ object StacItem {
 
   implicit val eqStacItem: Eq[StacItem] = Eq.fromUniversalEquals
 
-  implicit val encStacItem: Encoder[StacItem] = Encoder.forProduct10(
-    "id",
-    "stac_version",
-    "stac_extensions",
-    "type",
-    "geometry",
-    "bbox",
-    "links",
-    "assets",
-    "collection",
-    "properties"
-  )(item =>
-    (
-      item.id,
-      item.stacVersion,
-      item.stacExtensions,
-      item._type,
-      item.geometry,
-      item.bbox,
-      item.links,
-      item.assets,
-      item.collection,
-      item.properties
+  implicit val encStacItem: Encoder[StacItem] = Encoder
+    .forProduct10(
+      "id",
+      "stac_version",
+      "stac_extensions",
+      "type",
+      "geometry",
+      "bbox",
+      "links",
+      "assets",
+      "collection",
+      "properties"
+    )((item: StacItem) =>
+      (
+        item.id,
+        item.stacVersion,
+        item.stacExtensions,
+        item._type,
+        item.geometry,
+        item.bbox,
+        item.links,
+        item.assets,
+        item.collection,
+        item.properties
+      )
     )
-  )
+    .mapJson(_.dropNullValues)
 
   implicit val decStacItem: Decoder[StacItem] = Decoder.forProduct10(
     "id",

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacCollection.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacCollection.scala
@@ -66,7 +66,7 @@ object StacCollection {
       )
     )
 
-    baseEncoder(collection).deepMerge(collection.extensionFields.asJson)
+    baseEncoder(collection).deepMerge(collection.extensionFields.asJson).dropNullValues
   }
 
   implicit val decoderStacCollection: Decoder[StacCollection] = { c: HCursor =>

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacItem.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/StacItem.scala
@@ -29,31 +29,33 @@ object StacItem {
 
   implicit val eqStacItem: Eq[StacItem] = Eq.fromUniversalEquals
 
-  implicit val encStacItem: Encoder[StacItem] = Encoder.forProduct10(
-    "id",
-    "stac_version",
-    "stac_extensions",
-    "type",
-    "geometry",
-    "bbox",
-    "links",
-    "assets",
-    "collection",
-    "properties"
-  )(item =>
-    (
-      item.id,
-      item.stacVersion,
-      item.stacExtensions,
-      item._type,
-      item.geometry,
-      item.bbox,
-      item.links,
-      item.assets,
-      item.collection,
-      item.properties
+  implicit val encStacItem: Encoder[StacItem] = Encoder
+    .forProduct10(
+      "id",
+      "stac_version",
+      "stac_extensions",
+      "type",
+      "geometry",
+      "bbox",
+      "links",
+      "assets",
+      "collection",
+      "properties"
+    )((item: StacItem) =>
+      (
+        item.id,
+        item.stacVersion,
+        item.stacExtensions,
+        item._type,
+        item.geometry,
+        item.bbox,
+        item.links,
+        item.assets,
+        item.collection,
+        item.properties
+      )
     )
-  )
+    .mapJson(_.dropNullValues)
 
   implicit val decStacItem: Decoder[StacItem] = Decoder.forProduct10(
     "id",

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/ItemCollection.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/ItemCollection.scala
@@ -40,7 +40,7 @@ object ItemCollection {
         )
       )
 
-      baseEncoder(collection).deepMerge(collection.extensionFields.asJson)
+      baseEncoder(collection).deepMerge(collection.extensionFields.asJson).dropNullValues
     }
   }
 

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/StacAsset.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/StacAsset.scala
@@ -24,7 +24,7 @@ object StacAsset {
       Encoder.forProduct5("href", "title", "description", "roles", "type")(asset =>
         (asset.href, asset.title, asset.description, asset.roles, asset._type)
       )
-    baseEncoder(asset).deepMerge(asset.extensionFields.asJson)
+    baseEncoder(asset).deepMerge(asset.extensionFields.asJson).dropNullValues
   }
 
   implicit val decStacAsset: Decoder[StacAsset] = { c: HCursor =>

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/StacCatalog.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/StacCatalog.scala
@@ -50,7 +50,7 @@ object StacCatalog {
         )
       )
 
-    baseEncoder(catalog).deepMerge(catalog.extensionFields.asJson)
+    baseEncoder(catalog).deepMerge(catalog.extensionFields.asJson).dropNullValues
   }
 
   implicit val decCatalog: Decoder[StacCatalog] = { c: HCursor =>

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/StacLink.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/StacLink.scala
@@ -24,7 +24,7 @@ object StacLink {
         "title"
       )((link: StacLink) => (link.href, link.rel, link._type, link.title))
 
-    baseEncoder(link).deepMerge(link.extensionFields.asJson)
+    baseEncoder(link).deepMerge(link.extensionFields.asJson).dropNullValues
   }
 
   implicit val decStacLink: Decoder[StacLink] = { c: HCursor =>

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/StacProvider.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/StacProvider.scala
@@ -11,6 +11,6 @@ final case class StacProvider(
 )
 
 object StacProvider {
-  implicit val encStacProvider: Encoder[StacProvider] = deriveEncoder
+  implicit val encStacProvider: Encoder[StacProvider] = deriveEncoder[StacProvider].mapJson(_.dropNullValues)
   implicit val decStacProvider: Decoder[StacProvider] = deriveDecoder
 }

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/eo/Band.scala
@@ -18,13 +18,15 @@ object Band {
 
   implicit val eqBand: Eq[Band] = Eq.fromUniversalEquals
 
-  implicit val encBand: Encoder[Band] = Encoder.forProduct5(
-    "name",
-    "common_name",
-    "description",
-    "center_wavelength",
-    "full_width_half_max"
-  )(band => (band.name, band.commonName, band.description, band.centerWavelength, band.fullWidthHalfMax))
+  implicit val encBand: Encoder[Band] = Encoder
+    .forProduct5(
+      "name",
+      "common_name",
+      "description",
+      "center_wavelength",
+      "full_width_half_max"
+    )((band: Band) => (band.name, band.commonName, band.description, band.centerWavelength, band.fullWidthHalfMax))
+    .mapJson(_.dropNullValues)
 
   implicit val decBand: Decoder[Band] = Decoder.forProduct5(
     "name",

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/eo/EOItemExtension.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/extensions/eo/EOItemExtension.scala
@@ -19,7 +19,12 @@ object EOItemExtension {
 
   implicit val encEOItemExtension: Encoder.AsObject[EOItemExtension] = Encoder
     .AsObject[Map[String, Json]]
-    .contramapObject(band => Map("eo:bands" -> band.bands.asJson, "eo:cloud_cover" -> band.cloudCover.asJson))
+    .contramapObject((band: EOItemExtension) =>
+      Map("eo:bands" -> band.bands.asJson, "eo:cloud_cover" -> band.cloudCover.asJson)
+    )
+    .mapJsonObject(_.filter({ case (_, jValue) =>
+      !jValue.isNull
+    }))
 
   implicit val decEOItemExtension: Decoder[EOItemExtension] = Decoder.forProduct2(
     "eo:bands",


### PR DESCRIPTION
## Overview

This PR makes encoders aware of whether nulls should be dropped. For example, in links, `null`s are just nuisance data, so they should be dropped, while in intervals, they _mean something_, so they should not be dropped. I've published locally and consumed in Franklin with the data I have locally, and this change makes the responses valid according to `stac-node-validator` up to the values in `stac_extensions`, which is not `stac4s`'es responsibility.

### Checklist

- ~New tests have been added or existing tests have been modified~
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
