### PR TITLE
Update StacClient and SearchFilters JSON codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Changed
+- Update StacClient and SearchFilters JSON codecs [#305](https://github.com/azavea/stac4s/pull/305)
 
 ## [0.2.3] - 2021-05-04
 ### Fixed

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -7,7 +7,6 @@ import com.azavea.stac4s.jsTypes.TemporalExtent
 
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe._
-import io.circe.generic.semiauto._
 import io.circe.refined._
 
 case class SearchFilters(
@@ -23,13 +22,13 @@ case class SearchFilters(
 
 object SearchFilters extends ClientCodecs {
 
-  implicit val searchFilterDecoder: Decoder[SearchFilters] = { c =>
+  implicit val searchFiltersDecoder: Decoder[SearchFilters] = { c =>
     for {
       bbox              <- c.downField("bbox").as[Option[Bbox]]
       datetime          <- c.downField("datetime").as[Option[TemporalExtent]]
       intersects        <- c.downField("intersects").as[Option[Geometry]]
       collectionsOption <- c.downField("collections").as[Option[List[String]]]
-      itemsOption       <- c.downField("items").as[Option[List[String]]]
+      itemsOption       <- c.downField("ids").as[Option[List[String]]]
       limit             <- c.downField("limit").as[Option[NonNegInt]]
       query             <- c.get[Option[Map[String, List[Query]]]]("query")
       paginationToken   <- c.get[Option[PaginationToken]]("next")
@@ -47,5 +46,25 @@ object SearchFilters extends ClientCodecs {
     }
   }
 
-  implicit val searchFilterEncoder: Encoder[SearchFilters] = deriveEncoder
+  implicit val searchFiltersEncoder: Encoder[SearchFilters] = Encoder.forProduct8(
+    "bbox",
+    "datetime",
+    "intersects",
+    "collections",
+    "ids",
+    "limit",
+    "query",
+    "next"
+  )(filters =>
+    (
+      filters.bbox,
+      filters.datetime,
+      filters.intersects,
+      filters.collections,
+      filters.items,
+      filters.limit,
+      filters.query,
+      filters.next
+    )
+  )
 }

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SttpStacClient.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SttpStacClient.scala
@@ -6,9 +6,6 @@ import sttp.model.Uri
 
 object SttpStacClient {
 
-  def apply[F[_]: MonadError[*[_], Throwable]](
-      client: SttpBackend[F, Any],
-      baseUri: Uri
-  ): SttpStacClient[F] =
-    SttpStacClientF.instance[F, SearchFilters](client, baseUri)
+  def apply[F[_]: MonadError[*[_], Throwable]](client: SttpBackend[F, Any], baseUri: Uri): SttpStacClient[F] =
+    SttpStacClientF[F, SearchFilters](client, baseUri)
 }

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/package.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/package.scala
@@ -1,5 +1,6 @@
 package com.azavea.stac4s.api
 
 package object client {
-  type SttpStacClient[F[_]] = SttpStacClientF.Aux[F, SearchFilters]
+  type StacClient[F[_]]     = StacClientF[F, SearchFilters]
+  type SttpStacClient[F[_]] = SttpStacClientF[F, SearchFilters]
 }

--- a/modules/client/js/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientSpec.scala
+++ b/modules/client/js/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientSpec.scala
@@ -4,6 +4,6 @@ import com.azavea.stac4s.testing.JsInstances
 
 import sttp.client3.UriContext
 
-class SttpStacClientSpec extends SttpStacClientFSpec with JsInstances {
+class SttpStacClientSpec extends SttpStacClientFSpec[SearchFilters] with JsInstances {
   lazy val client = SttpStacClient(backend, uri"http://localhost:9090")
 }

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -7,7 +7,6 @@ import com.azavea.stac4s.jvmTypes.TemporalExtent
 import eu.timepit.refined.types.numeric.NonNegInt
 import geotrellis.vector.{io => _, _}
 import io.circe._
-import io.circe.generic.semiauto._
 import io.circe.refined._
 
 case class SearchFilters(
@@ -23,13 +22,13 @@ case class SearchFilters(
 
 object SearchFilters extends ClientCodecs {
 
-  implicit val searchFilterDecoder: Decoder[SearchFilters] = { c =>
+  implicit val searchFiltersDecoder: Decoder[SearchFilters] = { c =>
     for {
       bbox              <- c.downField("bbox").as[Option[Bbox]]
       datetime          <- c.downField("datetime").as[Option[TemporalExtent]]
       intersects        <- c.downField("intersects").as[Option[Geometry]]
       collectionsOption <- c.downField("collections").as[Option[List[String]]]
-      itemsOption       <- c.downField("items").as[Option[List[String]]]
+      itemsOption       <- c.downField("ids").as[Option[List[String]]]
       limit             <- c.downField("limit").as[Option[NonNegInt]]
       query             <- c.get[Option[Map[String, List[Query]]]]("query")
       paginationToken   <- c.get[Option[PaginationToken]]("next")
@@ -47,5 +46,25 @@ object SearchFilters extends ClientCodecs {
     }
   }
 
-  implicit val searchFilterEncoder: Encoder[SearchFilters] = deriveEncoder
+  implicit val searchFiltersEncoder: Encoder[SearchFilters] = Encoder.forProduct8(
+    "bbox",
+    "datetime",
+    "intersects",
+    "collections",
+    "ids",
+    "limit",
+    "query",
+    "next"
+  )(filters =>
+    (
+      filters.bbox,
+      filters.datetime,
+      filters.intersects,
+      filters.collections,
+      filters.items,
+      filters.limit,
+      filters.query,
+      filters.next
+    )
+  )
 }

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SttpStacClient.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SttpStacClient.scala
@@ -6,9 +6,6 @@ import sttp.model.Uri
 
 object SttpStacClient {
 
-  def apply[F[_]: MonadError[*[_], Throwable]](
-      client: SttpBackend[F, Any],
-      baseUri: Uri
-  ): SttpStacClient[F] =
-    SttpStacClientF.instance[F, SearchFilters](client, baseUri)
+  def apply[F[_]: MonadError[*[_], Throwable]](client: SttpBackend[F, Any], baseUri: Uri): SttpStacClient[F] =
+    SttpStacClientF[F, SearchFilters](client, baseUri)
 }

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/client.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/client.scala
@@ -1,5 +1,6 @@
 package com.azavea.stac4s.api
 
 package object client {
-  type SttpStacClient[F[_]] = SttpStacClientF.Aux[F, SearchFilters]
+  type StacClient[F[_]]     = StacClientF[F, SearchFilters]
+  type SttpStacClient[F[_]] = SttpStacClientF[F, SearchFilters]
 }

--- a/modules/client/jvm/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientSpec.scala
+++ b/modules/client/jvm/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientSpec.scala
@@ -4,6 +4,6 @@ import com.azavea.stac4s.testing.JvmInstances
 
 import sttp.client3.UriContext
 
-class SttpStacClientSpec extends SttpStacClientFSpec with JvmInstances {
+class SttpStacClientSpec extends SttpStacClientFSpec[SearchFilters] with JvmInstances {
   lazy val client = SttpStacClient(backend, uri"http://localhost:9090")
 }

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
@@ -4,10 +4,9 @@ import com.azavea.stac4s._
 
 import eu.timepit.refined.types.string.NonEmptyString
 
-trait StacClient[F[_]] {
-  type Filter
+trait StacClientF[F[_], S] {
   def search: F[List[StacItem]]
-  def search(filter: Filter): F[List[StacItem]]
+  def search(filter: S): F[List[StacItem]]
   def collections: F[List[StacCollection]]
   def collection(collectionId: NonEmptyString): F[StacCollection]
   def items(collectionId: NonEmptyString): F[List[StacItem]]

--- a/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
+++ b/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
@@ -16,13 +16,13 @@ import sttp.client3.testing.SttpBackendStub
 import sttp.model.Method
 import sttp.monad.EitherMonad
 
-trait SttpStacClientFSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll {
+trait SttpStacClientFSpec[S] extends AnyFunSpec with Matchers with BeforeAndAfterAll {
 
   def arbCollectionShort: Arbitrary[StacCollection]
   def arbItemCollectionShort: Arbitrary[ItemCollection]
   def arbItemShort: Arbitrary[StacItem]
 
-  def client: SttpStacClientF[Either[Throwable, *]]
+  def client: SttpStacClientF[Either[Throwable, *], S]
 
   lazy val backend =
     SttpBackendStub(EitherMonad)


### PR DESCRIPTION
## Overview

This PR updates SearchFilters codecs (see https://github.com/azavea/franklin/pull/708) as well as simplifies the StacClient interface making it 'simple'. The type memeber is removed and moved into the type parameter. Without this PR it would be hard to work with such interface and mix logging on the client side (see the POC https://github.com/geotrellis/geotrellis-server/pull/367/files)

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
