### PR TITLE
Add Scala 2.13 cross compilation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,63 +1,84 @@
-aliases:
-  - &run_cibuild
-    - checkout
-    - restore_cache:
-        keys:
-          - sbt-cache-{{ checksum "project/Versions.scala" }}
-    - run:
-        name: Executing cibuild
-        command: ./scripts/test
-    - store_test_results:
-        path: modules/core-test/jvm/target/test-reports
-    - store_test_results:
-        path: modules/core-test/js/target/test-reports
-    - save_cache:
-        key: sbt-cache-{{ checksum "project/Versions.scala" }}
-        paths:
-          - "~/.ivy2/cache"
-          - "~/.sbt"
-          - "~/.cache/coursier"
+version: 2.1
 
-  - &run_cipublish
-    - checkout
-    - restore_cache:
-        keys:
-          - sbt-cache-{{ checksum "project/Versions.scala" }}
-    - run:
-        name: "Import signing key"
-        command: |
-          gpg --keyserver keyserver.ubuntu.com \
-            --recv-keys 0x713F9F29598CFFF3 && \
-          echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
-          gpg --import signing_key.asc
-    - run:
-        name: Executing cipublish
-        command: ./scripts/cipublish
-
-  - &openjdk8-scala2_12_environment
+executors:
+  executor-openjdk8:
     docker:
       - image: circleci/openjdk:8-jdk-node
         environment:
           # https://circleci.com/docs/2.0/java-oom/
           _JAVA_OPTIONS: "-Xms128m -Xmx2g"
 
-version: 2
+jobs:
+  openjdk8-build:
+    parameters:
+      scala-version:
+        type: string
+    executor: executor-openjdk8
+    steps: 
+      - checkout
+      - restore_cache:
+          keys:
+            - sbt-cache-{{ checksum "project/Versions.scala" }}
+      - run:
+          name: Executing cibuild
+          command: |
+            export SCALA_VERSION=<< parameters.scala-version >>
+            ./scripts/test
+      - store_test_results:
+          path: modules/core-test/jvm/target/test-reports
+      - store_test_results:
+          path: modules/core-test/js/target/test-reports
+      - save_cache:
+          key: sbt-cache-{{ checksum "project/Versions.scala" }}
+          paths:
+            - "~/.ivy2/cache"
+            - "~/.sbt"
+            - "~/.cache/coursier"
+
+  openjdk8-deploy:
+    parameters:
+      scala-version:
+        type: string
+    executor: executor-openjdk8
+    steps: 
+      - checkout
+      - restore_cache:
+          keys:
+            - sbt-cache-{{ checksum "project/Versions.scala" }}
+      - run:
+          name: "Import signing key"
+          command: |
+            gpg --keyserver keyserver.ubuntu.com \
+              --recv-keys 0x713F9F29598CFFF3 && \
+            echo "${GPG_KEY}" | base64 -d > signing_key.asc && \
+            gpg --import signing_key.asc
+      - run:
+          name: Executing cipublish
+          command: |
+            export SCALA_VERSION=<< parameters.scala-version >>
+            ./scripts/cipublish
+
 workflows:
-  version: 2
   build:
     jobs:
-      - "openjdk8-scala2.12":
-          # required since openjdk8-scala2.12_deploy has tag filters AND requires
-          # openjdk8-scala2.12
+      - openjdk8-build:
+          matrix:
+            parameters:
+              scala-version: ["2.12.13", "2.13.5"]
+          # required since openjdk8-deploy has tag filters AND requires
+          # openjdk8
           # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
           filters:
             tags:
               only:
                 - /^(v.*)$/
-      - "openjdk8-scala2.12_deploy":
+      - openjdk8-deploy:
+          matrix:
+            parameters:
+              scala-version: ["2.12.13"]
           context: sonatype-azavea-signing-key
           requires:
-            - "openjdk8-scala2.12"
+            - openjdk8-build
           filters:
             tags:
               only:
@@ -65,12 +86,3 @@ workflows:
             branches:
               ignore:
                 - /^(.*)$/
-
-jobs:
-  "openjdk8-scala2.12":
-    <<: *openjdk8-scala2_12_environment
-    steps: *run_cibuild
-
-  "openjdk8-scala2.12_deploy":
-    <<: *openjdk8-scala2_12_environment
-    steps: *run_cipublish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Added
+- Add Scala 2.13 cross compilation [#310](https://github.com/azavea/stac4s/pull/310)
 
 ## [0.4.0] - 2021-05-12
 ### Fixed

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import xerial.sbt.Sonatype._
+import Dependencies._
 
 lazy val commonSettings = Seq(
   // We are overriding the default behavior of sbt-git which, by default, only
@@ -13,6 +14,7 @@ lazy val commonSettings = Seq(
       git.gitDescribedVersion.value.get
   },
   scalaVersion := "2.12.13",
+  crossScalaVersions := List("2.12.13", "2.13.5"),
   Global / cancelable := true,
   scalafmtOnCompile := true,
   ThisBuild / scapegoatVersion := Versions.Scapegoat,
@@ -100,20 +102,26 @@ lazy val credentialSettings = Seq(
   ).flatten
 )
 
-val jvmGeometryDependencies = Seq(
-  "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
-  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis
-)
+val jvmGeometryDependencies = Def.setting {
+  Seq(
+    "org.locationtech.jts" % "jts-core" % Versions.Jts,
+    geotrellis("vector").value
+  )
+}
 
-val coreDependenciesJVM = Seq(
-  "org.threeten" % "threeten-extra" % Versions.ThreeTenExtra
-) ++ jvmGeometryDependencies
+val coreDependenciesJVM = Def.setting {
+  Seq(
+    "org.threeten" % "threeten-extra" % Versions.ThreeTenExtra
+  ) ++ jvmGeometryDependencies.value
+}
 
-val testingDependenciesJVM = Seq(
-  "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis,
-  "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
-  "org.threeten"                 % "threeten-extra"    % Versions.ThreeTenExtra
-)
+val testingDependenciesJVM = Def.setting {
+  Seq(
+    geotrellis("vector").value,
+    "org.locationtech.jts" % "jts-core"       % Versions.Jts,
+    "org.threeten"         % "threeten-extra" % Versions.ThreeTenExtra
+  )
+}
 
 val testRunnerDependenciesJVM = Seq(
   "io.circe"          %% "circe-testing"   % Versions.Circe                   % Test,
@@ -149,7 +157,7 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel"              %%% "cats-kernel"      % Versions.Cats
     )
   })
-  .jvmSettings(libraryDependencies ++= coreDependenciesJVM)
+  .jvmSettings(libraryDependencies ++= coreDependenciesJVM.value)
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.2.2")
 
 lazy val coreJVM = core.jvm
@@ -173,7 +181,7 @@ lazy val testing = crossProject(JSPlatform, JVMPlatform)
       "org.typelevel"     %%% "cats-core"             % Versions.Cats
     )
   )
-  .jvmSettings(libraryDependencies ++= testingDependenciesJVM)
+  .jvmSettings(libraryDependencies ++= testingDependenciesJVM.value)
   .jsSettings(
     libraryDependencies ++= Seq(
       "io.github.cquiroz" %%% "scala-java-time" % "2.2.2" % Test
@@ -228,7 +236,7 @@ lazy val client = crossProject(JSPlatform, JVMPlatform)
     )
   )
   .jsSettings(libraryDependencies += "io.github.cquiroz" %%% "scala-java-time" % "2.2.2")
-  .jvmSettings(libraryDependencies ++= jvmGeometryDependencies)
+  .jvmSettings(libraryDependencies ++= jvmGeometryDependencies.value)
 
 lazy val clientJVM = client.jvm
 lazy val clientJS  = client.js

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
@@ -21,6 +21,7 @@ trait ClientCodecs {
       case Some(start) :: Some(end) :: _ if start == end => s"${start.toString}"
       case Some(start) :: None :: _                      => s"${start.toString}/.."
       case None :: Some(end) :: _                        => s"../${end.toString}"
+      case x                                             => throw new scala.MatchError(x)
     }
 
   private def temporalExtentFromString(str: String): Either[String, TemporalExtent] = {

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/utils/ClientCodecs.scala
@@ -21,6 +21,7 @@ trait ClientCodecs {
       case Some(start) :: Some(end) :: _ if start == end => s"${start.toString}"
       case Some(start) :: None :: _                      => s"${start.toString}/.."
       case None :: Some(end) :: _                        => s"../${end.toString}"
+      case x                                             => throw new scala.MatchError(x)
     }
 
   private def temporalExtentFromString(str: String): Either[String, TemporalExtent] = {

--- a/modules/core/js/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
+++ b/modules/core/js/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
@@ -65,6 +65,7 @@ trait ForeignImplicits {
       case parts if parts.length < 2 =>
         val message = s"Too few elements for temporal extent: $parts"
         throw new ParsingFailure(message, new Exception(message))
+      case x => throw new scala.MatchError(x)
     }
   }
 

--- a/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
+++ b/modules/core/jvm/src/main/scala/com/azavea/stac4s/meta/ForeignImplicits.scala
@@ -66,6 +66,7 @@ trait ForeignImplicits {
       case parts if parts.length < 2 =>
         val message = s"Too few elements for temporal extent: $parts"
         throw new ParsingFailure(message, new Exception(message))
+      case x => throw new scala.MatchError(x)
     }
   }
 

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/ProductFieldNames.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/ProductFieldNames.scala
@@ -4,6 +4,8 @@ import shapeless.ops.hlist.ToTraversable
 import shapeless.ops.record.Keys
 import shapeless.{HList, LabelledGeneric}
 
+import scala.annotation.nowarn
+
 trait ProductFieldNames[T] {
   def get: Set[String]
 }
@@ -11,6 +13,7 @@ trait ProductFieldNames[T] {
 object ProductFieldNames {
   def apply[T](implicit ev: ProductFieldNames[T]): ProductFieldNames[T] = ev
 
+  @nowarn // parameter value evidence$1 in method fromLabelledGeneric is never used
   @SuppressWarnings(Array("all"))
   implicit def fromLabelledGeneric[T: LabelledGeneric.Aux[*, L], L <: HList, K <: HList](implicit
       keys: Keys.Aux[L, K],

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,3 +1,6 @@
+import sbt._
+import sbt.Keys._
+
 object Versions {
   val Cats                    = "2.6.0"
   val Circe                   = "0.13.0"
@@ -17,4 +20,19 @@ object Versions {
   val SttpModel               = "1.4.4"
   val SttpShared              = "1.2.2"
   val ThreeTenExtra           = "1.6.0"
+}
+
+object Dependencies {
+
+  private def ver(for212: String, for213: String) = Def.setting {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 12)) => for212
+      case Some((2, 13)) => for213
+      case _             => sys.error("not good")
+    }
+  }
+
+  def geotrellis(module: String) = Def.setting {
+    "org.locationtech.geotrellis" %% s"geotrellis-$module" % ver(Versions.GeoTrellis, "3.6.1-SNAPSHOT").value
+  }
 }

--- a/sbt
+++ b/sbt
@@ -34,8 +34,8 @@
 
 set -o pipefail
 
-declare -r sbt_release_version="1.5.0"
-declare -r sbt_unreleased_version="1.5.0"
+declare -r sbt_release_version="1.5.2"
+declare -r sbt_unreleased_version="1.5.2"
 
 declare -r latest_213="2.13.5"
 declare -r latest_212="2.12.13"
@@ -385,12 +385,10 @@ usage() {
   set_sbt_version
   cat <<EOM
 Usage: $script_name [options]
-
 Note that options which are passed along to sbt begin with -- whereas
 options to this runner use a single dash. Any sbt command can be scheduled
 to run first by prefixing the command with --, so --warn, --error and so on
 are not special.
-
   -h | -help         print this message
   -v                 verbose operation (this runner is chattier)
   -d, -w, -q         aliases for --debug, --warn, --error (q means quiet)
@@ -408,7 +406,6 @@ are not special.
   -batch             Disable interactive mode
   -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
   -script <file>     Run the specified file as a scala script
-
   # sbt version (default: sbt.version from $buildProps if present, otherwise $sbt_release_version)
   -sbt-version <version>  use the specified version of sbt (default: $sbt_release_version)
   -sbt-force-latest       force the use of the latest release of sbt: $sbt_release_version
@@ -416,7 +413,6 @@ are not special.
   -sbt-jar      <path>    use the specified jar as the sbt launcher
   -sbt-launch-dir <path>  directory to hold sbt launchers (default: $sbt_launch_dir)
   -sbt-launch-repo <url>  repo url for downloading sbt launcher jar (default: $(url_base "$sbt_version"))
-
   # scala version (default: as chosen by sbt)
   -28                        use $latest_28
   -29                        use $latest_29
@@ -427,10 +423,8 @@ are not special.
   -scala-home <path>         use the scala build at the specified directory
   -scala-version <version>   use the specified version of scala
   -binary-version <version>  use the specified scala version when searching for dependencies
-
   # java version (default: java from PATH, currently $(java -version 2>&1 | grep version))
   -java-home <path>          alternate JAVA_HOME
-
   # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
   # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
   <default>         $(default_jvm_opts)
@@ -440,14 +434,12 @@ are not special.
   -jvm-opts <path>  file containing jvm args (if not given, .jvmopts in project root is used if present)
   -Dkey=val         pass -Dkey=val directly to the jvm
   -J-X              pass option -X directly to the jvm (-J is stripped)
-
   # passing options to sbt, OR to this runner
   SBT_OPTS          environment variable holding either the sbt args directly, or
                     the reference to a file containing sbt args if given path is prepended by '@' (e.g. '@/etc/sbtopts')
                     Note: "@"-file is overridden by local '.sbtopts' or '-sbt-opts' argument.
   -sbt-opts <path>  file containing sbt args (if not given, .sbtopts in project root is used if present)
   -S-X              add -X to sbt's scalacOptions (-S is stripped)
-
   # passing options exclusively to this runner
   SBTX_OPTS         environment variable holding either the sbt-extras args directly, or
                     the reference to a file containing sbt-extras args if given path is prepended by '@' (e.g. '@/etc/sbtxopts')
@@ -600,7 +592,6 @@ fi
 $(pwd) doesn't appear to be an sbt project.
 If you want to start sbt anyway, run:
   $0 -sbt-create
-
 EOM
   exit 1
 }

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -20,10 +20,10 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         echo "Publishing artifacts to Sonatype"
         if [[ -n "${CIRCLE_TAG}" ]]; then
             echo "Building with ${CIRCLE_TAG}"
-            ./sbt ";sonatypeOpen;publish;sonatypeRelease"
+            ./sbt "++$SCALA_VERSION" ";sonatypeOpen;publish;sonatypeRelease"
         else
             echo "Building untagged"
-            ./sbt publish
+            ./sbt "++$SCALA_VERSION" publish
         fi
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -18,7 +18,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
         usage
     else
         echo "Linting Scala source code and executing tests"
-        ./sbt ";\
+        ./sbt "++$SCALA_VERSION" ";\
             scalafix --check; \
             scalafmtCheck; \
             scalafmtSbtCheck; \


### PR DESCRIPTION
## Overview

This PR adds Scala 2.13 cross compilation and adjusts the CI to run tests against Scala 2.13. 
However, it would not push 2.13 release artifacts into the sonatype since 2.13 artifacts require GT SNAPSHOT deps.

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

Closes #77
