### PR TITLE
Make StacClient type alias a trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add Scala 2.13 cross compilation [#310](https://github.com/azavea/stac4s/pull/310)
 
+### Changed
+- Make StacClient type alias a trait [#325](https://github.com/azavea/stac4s/pull/325)
+
 ## [0.4.0] - 2021-05-12
 ### Fixed
 - Item properties are no longer treated as a black box JsonObject [#309](https://github.com/azavea/stac4s/pull/309)

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val commonSettings = Seq(
       git.gitDescribedVersion.value.get
   },
   scalaVersion := "2.12.13",
-  crossScalaVersions := List("2.12.13", "2.13.5"),
+  crossScalaVersions := List("2.12.13", "2.13.6"),
   Global / cancelable := true,
   scalafmtOnCompile := true,
   ThisBuild / scapegoatVersion := Versions.Scapegoat,

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/StacClient.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/StacClient.scala
@@ -1,0 +1,3 @@
+package com.azavea.stac4s.api.client
+
+trait StacClient[F[_]] extends StacClientF[F, SearchFilters]

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/package.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/package.scala
@@ -1,6 +1,5 @@
 package com.azavea.stac4s.api
 
 package object client {
-  type StacClient[F[_]]     = StacClientF[F, SearchFilters]
   type SttpStacClient[F[_]] = SttpStacClientF[F, SearchFilters]
 }

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/StacClient.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/StacClient.scala
@@ -1,0 +1,3 @@
+package com.azavea.stac4s.api.client
+
+trait StacClient[F[_]] extends StacClientF[F, SearchFilters]

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/client.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/client.scala
@@ -1,6 +1,5 @@
 package com.azavea.stac4s.api
 
 package object client {
-  type StacClient[F[_]]     = StacClientF[F, SearchFilters]
   type SttpStacClient[F[_]] = SttpStacClientF[F, SearchFilters]
 }


### PR DESCRIPTION
## Overview

This PR makes `StacClient` a trait and not a type alias, otherwise client children is really inconvenient to define:

i.e. right now it is:

```scala
class StacClientLoggingMid[F[_]] extends StacClientF[Mid[F, *], SearchFilters]
```

with this PR it becomes:

```scala
class StacClientLoggingMid[F[_]] extends StacClient[Mid[F, *]]
```

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
