### PR TITLE
Add STACClient itemUpdate, itemPatch and itemDelete methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Add STACClient itemUpdate, itemPatch and itemDelete methods [#346](https://github.com/azavea/stac4s/pull/346)
+
 ## [0.5.0] - 2021-06-02
 ### Added
 - Add Scala 2.13 cross compilation [#310](https://github.com/azavea/stac4s/pull/310)

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -1,6 +1,6 @@
 package com.azavea.stac4s.api.client
 
-import com.azavea.stac4s.api.client.utils.ClientCodecs
+import com.azavea.stac4s.api.client.util.ClientCodecs
 import com.azavea.stac4s.geometry.Geometry
 import com.azavea.stac4s.{Bbox, TemporalExtent}
 

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/util/ClientCodecs.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/util/ClientCodecs.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.api.client.utils
+package com.azavea.stac4s.api.client.util
 
 import com.azavea.stac4s.TemporalExtent
 

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -1,6 +1,6 @@
 package com.azavea.stac4s.api.client
 
-import com.azavea.stac4s.api.client.utils.ClientCodecs
+import com.azavea.stac4s.api.client.util.ClientCodecs
 import com.azavea.stac4s.{Bbox, TemporalExtent}
 
 import eu.timepit.refined.types.numeric.NonNegInt

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/util/ClientCodecs.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/util/ClientCodecs.scala
@@ -1,4 +1,4 @@
-package com.azavea.stac4s.api.client.utils
+package com.azavea.stac4s.api.client.util
 
 import com.azavea.stac4s.TemporalExtent
 

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/ETag.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/ETag.scala
@@ -1,0 +1,15 @@
+package com.azavea.stac4s.api.client
+
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.refined._
+import io.circe.{Decoder, Encoder}
+
+import scala.annotation.nowarn
+
+case class ETag[T](entity: T, tag: Option[NonEmptyString])
+
+object ETag {
+  @nowarn implicit def encoderETag[T: Encoder]: Encoder[ETag[T]] = deriveEncoder
+  @nowarn implicit def decoderETag[T: Decoder]: Decoder[ETag[T]] = deriveDecoder
+}

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
@@ -1,19 +1,23 @@
 package com.azavea.stac4s.api.client
 
-import com.azavea.stac4s._
+import com.azavea.stac4s.{StacCollection, StacItem}
 
 import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Json
 
 trait StacClientF[F[_], S] {
   def collection(collectionId: NonEmptyString): F[StacCollection]
-  def item(collectionId: NonEmptyString, itemId: NonEmptyString): F[StacItem]
-  def itemCreate(collectionId: NonEmptyString, item: StacItem): F[StacItem]
   def collectionCreate(collection: StacCollection): F[StacCollection]
+  def item(collectionId: NonEmptyString, itemId: NonEmptyString): F[ETag[StacItem]]
+  def itemCreate(collectionId: NonEmptyString, item: StacItem): F[ETag[StacItem]]
+  def itemUpdate(collectionId: NonEmptyString, item: ETag[StacItem]): F[ETag[StacItem]]
+  def itemPatch(collectionId: NonEmptyString, itemId: NonEmptyString, patch: ETag[Json]): F[ETag[StacItem]]
+  def itemDelete(collectionId: NonEmptyString, itemId: NonEmptyString): F[Either[String, String]]
 }
 
 trait StreamingStacClientF[F[_], G[_], S] extends StacClientF[F, S] {
+  def collections: G[StacCollection]
   def search: G[StacItem]
   def search(filter: S): G[StacItem]
-  def collections: G[StacCollection]
   def items(collectionId: NonEmptyString): G[StacItem]
 }

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/util/syntax/package.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/util/syntax/package.scala
@@ -1,0 +1,29 @@
+package com.azavea.stac4s.api.client.util
+
+import com.azavea.stac4s.api.client.ETag
+
+import eu.timepit.refined.types.string.NonEmptyString
+import sttp.client3.{RequestT, Response}
+import sttp.model.HeaderNames
+
+package object syntax {
+
+  implicit class RequestTOps[U[_], T, -R](val self: RequestT[U, T, R]) extends AnyVal {
+    def header(k: String, v: Option[String]): RequestT[U, T, R] = v.fold(self)(self.header(k, _))
+
+    @SuppressWarnings(Array("UnusedMethodParameter"))
+    def header(k: String, v: Option[NonEmptyString])(implicit d: DummyImplicit): RequestT[U, T, R] =
+      v.fold(self)(e => self.header(k, e.value))
+
+    def headerIfMatch(v: Option[NonEmptyString]): RequestT[U, T, R] = header(HeaderNames.IfMatch, v)
+    def headerETag(v: Option[NonEmptyString]): RequestT[U, T, R]    = header(HeaderNames.Etag, v)
+  }
+
+  implicit class ResponseOps[T](val self: Response[T]) extends AnyVal {
+    def headerETag: Option[NonEmptyString] = self.header(HeaderNames.Etag).flatMap(NonEmptyString.from(_).toOption)
+  }
+
+  implicit class ResponseEitherOps[E, T](val self: Response[Either[E, T]]) extends AnyVal {
+    def bodyETag: Either[E, ETag[T]] = self.body.map(ETag(_, self.headerETag))
+  }
+}

--- a/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
+++ b/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpStacClientFSpec.scala
@@ -4,19 +4,24 @@ import com.azavea.stac4s.{ItemCollection, StacCollection, StacItem}
 
 import cats.syntax.either._
 import eu.timepit.refined.types.all.NonEmptyString
-import io.circe.JsonObject
+import io.circe.{JsonObject, parser}
 import io.circe.syntax._
 import org.scalacheck.Arbitrary
 import org.scalacheck.resample._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
-import sttp.client3.Response
+import sttp.client3.{Response, StringBody}
 import sttp.client3.testing.SttpBackendStub
 import sttp.model.Method
 import sttp.monad.EitherMonad
 
-trait SttpStacClientFSpec[S] extends AnyFunSpec with Matchers with BeforeAndAfterAll with SttpEitherInstances {
+trait SttpStacClientFSpec[S]
+    extends AnyFunSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with SttpEitherInstances
+    with SttpSyntax {
 
   def arbCollectionShort: Arbitrary[StacCollection]
   def arbItemCollectionShort: Arbitrary[ItemCollection]
@@ -28,64 +33,77 @@ trait SttpStacClientFSpec[S] extends AnyFunSpec with Matchers with BeforeAndAfte
   lazy val backend =
     SttpBackendStub(EitherMonad)
       .whenRequestMatches(_.uri.path == Seq("search"))
-      .thenRespondF { _ =>
-        Response
-          .ok(arbItemCollectionShort.arbitrary.resample().asJson.asRight)
-          .asRight
-      }
+      .thenRespondF { _ => Response.json(arbItemCollectionShort.arbitrary.resample().asJson) }
       .whenRequestMatches {
         case req if req.method == Method.GET => req.uri.path == Seq("collections")
         case _                               => false
       }
       .thenRespondF { _ =>
-        Response
-          .ok(JsonObject("collections" -> arbCollectionShort.arbitrary.sample.toList.asJson).asJson.asRight)
-          .asRight
+        Response.json(JsonObject("collections" -> arbCollectionShort.arbitrary.sample.toList.asJson).asJson)
       }
       .whenRequestMatches {
         case req if req.method == Method.GET => req.uri.path == Seq("collections", "collection_id")
         case _                               => false
       }
-      .thenRespondF { _ =>
-        Response
-          .ok(arbCollectionShort.arbitrary.resample().asRight)
-          .asRight
-      }
+      .thenRespondF { _ => Response.item(arbCollectionShort.arbitrary.resample()) }
       .whenRequestMatches {
         case req if req.method == Method.GET => req.uri.path == Seq("collections", "collection_id", "items")
         case _                               => false
       }
-      .thenRespondF { _ =>
-        Response
-          .ok(arbItemCollectionShort.arbitrary.sample.asJson.asRight)
-          .asRight
+      .thenRespondF { _ => Response.json(arbItemCollectionShort.arbitrary.sample.asJson) }
+      .whenRequestMatches {
+        case req if req.method == Method.GET => req.uri.path == Seq("collections", "collection_id", "items", "item_id")
+        case _                               => false
       }
-      .whenRequestMatches(_.uri.path == Seq("collections", "collection_id", "items", "item_id"))
-      .thenRespondF { _ =>
-        Response
-          .ok(arbItemShort.arbitrary.resample().asRight)
-          .asRight
+      .thenRespondF { _ => Response.item(arbItemShort.arbitrary.resample()) }
+      .whenRequestMatches {
+        case req if req.method == Method.PUT => req.uri.path == Seq("collections", "collection_id", "items", "item_id")
+        case _                               => false
       }
+      .thenRespondF { req =>
+        req.body match {
+          case sb: StringBody => Response.item(parser.parse(sb.s).flatMap(_.as[StacItem]).valueOr(throw _))
+          case _              => Response.item(arbItemShort.arbitrary.resample())
+        }
+      }
+      .whenRequestMatches {
+        case req if req.method == Method.PATCH =>
+          req.uri.path == Seq("collections", "collection_id", "items", "item_id")
+        case _ => false
+      }
+      .thenRespondF { _ => Response.item(arbItemShort.arbitrary.resample()) }
+      .whenRequestMatches {
+        case req if req.method == Method.DELETE =>
+          req.uri.path == Seq("collections", "collection_id", "items", "item_id")
+        case _ => false
+      }
+      .thenRespondF { _ => Response.empty }
       .whenRequestMatches {
         case req if req.method == Method.POST => req.uri.path == Seq("collections", "collection_id", "items")
         case _                                => false
       }
-      .thenRespondF { _ =>
-        Response
-          .ok(arbItemShort.arbitrary.resample().asRight)
-          .asRight
+      .thenRespondF { req =>
+        req.body match {
+          case sb: StringBody => Response.item(parser.parse(sb.s).flatMap(_.as[StacItem]).valueOr(throw _))
+          case _              => Response.item(arbItemShort.arbitrary.resample())
+        }
       }
       .whenRequestMatches {
         case req if req.method == Method.POST => req.uri.path == Seq("collections")
         case _                                => false
       }
-      .thenRespondF { _ =>
-        Response
-          .ok(arbCollectionShort.arbitrary.resample().asRight)
-          .asRight
+      .thenRespondF { req =>
+        req.body match {
+          case sb: StringBody => Response.item(parser.parse(sb.s).flatMap(_.as[StacCollection]).valueOr(throw _))
+          case _              => Response.item(arbCollectionShort.arbitrary.resample())
+        }
+
       }
 
   describe("SttpStacClientSpec") {
+    val collectionId = NonEmptyString.unsafeFrom("collection_id")
+    val itemId       = NonEmptyString.unsafeFrom("item_id")
+
     it("search") {
       client.search.compile.toList
         .valueOr(throw _)
@@ -99,30 +117,7 @@ trait SttpStacClientFSpec[S] extends AnyFunSpec with Matchers with BeforeAndAfte
 
     it("collection") {
       client
-        .collection(NonEmptyString.unsafeFrom("collection_id"))
-        .valueOr(throw _)
-        .id should not be empty
-    }
-
-    it("items") {
-      client
-        .items(NonEmptyString.unsafeFrom("collection_id"))
-        .compile
-        .toList
-        .valueOr(throw _)
-        .map(_.id should not be empty)
-    }
-
-    it("item") {
-      client
-        .item(NonEmptyString.unsafeFrom("collection_id"), NonEmptyString.unsafeFrom("item_id"))
-        .valueOr(throw _)
-        .id should not be empty
-    }
-
-    it("itemCreate") {
-      client
-        .itemCreate(NonEmptyString.unsafeFrom("collection_id"), arbItemShort.arbitrary.resample())
+        .collection(collectionId)
         .valueOr(throw _)
         .id should not be empty
     }
@@ -132,6 +127,53 @@ trait SttpStacClientFSpec[S] extends AnyFunSpec with Matchers with BeforeAndAfte
         .collectionCreate(arbCollectionShort.arbitrary.resample())
         .valueOr(throw _)
         .id should not be empty
+    }
+
+    it("items") {
+      client
+        .items(collectionId)
+        .compile
+        .toList
+        .valueOr(throw _)
+        .map(_.id should not be empty)
+    }
+
+    it("item") {
+      client
+        .item(collectionId, itemId)
+        .valueOr(throw _)
+        .entity
+        .id should not be empty
+    }
+
+    it("itemCreate") {
+      val item = arbItemShort.arbitrary.resample().etag
+      client
+        .itemCreate(collectionId, item.entity)
+        .valueOr(throw _) should be(item)
+    }
+
+    it("itemUpdate") {
+      val item = arbItemShort.arbitrary.resample().copy(id = "item_id").etag
+      client
+        .itemUpdate(collectionId, item)
+        .valueOr(throw _) should be(item)
+    }
+
+    it("itemPatch") {
+      val patch = JsonObject("properties" -> Map("key" -> "value").asJson).asJson.etag
+      client
+        .itemPatch(collectionId, itemId, patch)
+        .valueOr(throw _)
+        .entity
+        .id should not be empty
+    }
+
+    it("itemDelete") {
+      client
+        .itemDelete(collectionId, itemId)
+        .valueOr(throw _)
+        .valueOr(str => throw new Exception(str)) should be(empty)
     }
   }
 

--- a/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpSyntax.scala
+++ b/modules/client/shared/src/test/scala/com/azavea/stac4s/api/client/SttpSyntax.scala
@@ -1,0 +1,26 @@
+package com.azavea.stac4s.api.client
+
+import cats.syntax.either._
+import cats.syntax.option._
+import eu.timepit.refined.types.string.NonEmptyString
+import io.circe.Json
+import sttp.client3.Response
+import sttp.model.{Header, HeaderNames, StatusCode}
+
+trait SttpSyntax {
+
+  implicit class ResponseOps(self: Response.type) {
+
+    def empty: Either[Nothing, Response[Either[Nothing, String]]] = Response.ok("".asRight).asRight
+
+    def item[T](item: T): Either[Nothing, Response[Either[Nothing, T]]] =
+      Response(item.asRight, StatusCode.Ok, "OK", Header(HeaderNames.Etag, item.##.toString) :: Nil).asRight
+
+    def json(json: Json): Either[Nothing, Response[Either[Nothing, Json]]] =
+      Response.ok(json.asRight).asRight
+  }
+
+  implicit class EtagOps[T](val self: T) {
+    def etag: ETag[T] = ETag(self, NonEmptyString.unsafeFrom(self.##.toString).some)
+  }
+}


### PR DESCRIPTION
## Overview

This PR finishes the StacAPIClient functionality. 

[STAC Catalog Update flow example](https://gist.github.com/pomadchin/86e61dc151fbf2be9fa9f824473071b7#file-staccatalogupdate-scala-L66-L90)

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
