### PR TITLE
Add a correct content type to POST requests and SearchFilters adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Add a correct content type to POST requests [#359](https://github.com/azavea/stac4s/pull/359)
 
 ## [0.6.0] - 2021-07-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
-### Fixed
-- Add a correct content type to POST requests [#359](https://github.com/azavea/stac4s/pull/359)
+### Changed
+- Add a correct content type to POST requests and SearchFilters adjustments [#359](https://github.com/azavea/stac4s/pull/359)
 
 ## [0.6.0] - 2021-07-01
 ### Added

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -14,10 +14,10 @@ case class SearchFilters(
     bbox: Option[Bbox] = None,
     datetime: Option[TemporalExtent] = None,
     intersects: Option[Geometry] = None,
-    collections: List[String] = Nil,
-    items: List[String] = Nil,
+    collections: Option[List[String]] = None,
+    items: Option[List[String]] = None,
     limit: Option[NonNegInt] = None,
-    query: Map[String, List[Query]] = Map.empty,
+    query: Option[Map[String, List[Query]]] = None,
     next: Option[PaginationToken] = None
 )
 
@@ -39,10 +39,10 @@ object SearchFilters extends ClientCodecs {
         bbox,
         datetime,
         intersects,
-        collectionsOption.getOrElse(Nil),
-        itemsOption.getOrElse(Nil),
+        collectionsOption,
+        itemsOption,
         limit,
-        query getOrElse Map.empty,
+        query,
         paginationToken
       )
     }

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -4,6 +4,7 @@ import com.azavea.stac4s.api.client.util.ClientCodecs
 import com.azavea.stac4s.geometry.Geometry
 import com.azavea.stac4s.{Bbox, TemporalExtent}
 
+import cats.syntax.option._
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe._
 import io.circe.refined._
@@ -17,7 +18,7 @@ case class SearchFilters(
     collections: List[String] = Nil,
     items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
-    query: Option[Map[String, List[Query]]] = None,
+    query: Map[String, List[Query]] = Map.empty,
     next: Option[PaginationToken] = None
 )
 
@@ -42,7 +43,7 @@ object SearchFilters extends ClientCodecs {
         collectionsOption getOrElse Nil,
         itemsOption getOrElse Nil,
         limit,
-        query,
+        query getOrElse Map.empty,
         paginationToken
       )
     }
@@ -62,10 +63,10 @@ object SearchFilters extends ClientCodecs {
       filters.bbox,
       filters.datetime,
       filters.intersects,
-      filters.collections,
-      filters.items,
+      filters.collections.some.filter(_.nonEmpty),
+      filters.items.some.filter(_.nonEmpty),
       filters.limit,
-      filters.query,
+      filters.query.some.filter(_.nonEmpty),
       filters.next
     )
   )

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -14,8 +14,8 @@ case class SearchFilters(
     bbox: Option[Bbox] = None,
     datetime: Option[TemporalExtent] = None,
     intersects: Option[Geometry] = None,
-    collections: Option[List[String]] = None,
-    items: Option[List[String]] = None,
+    collections: List[String] = Nil,
+    items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
     query: Option[Map[String, List[Query]]] = None,
     next: Option[PaginationToken] = None
@@ -39,8 +39,8 @@ object SearchFilters extends ClientCodecs {
         bbox,
         datetime,
         intersects,
-        collectionsOption,
-        itemsOption,
+        collectionsOption getOrElse Nil,
+        itemsOption getOrElse Nil,
         limit,
         query,
         paginationToken

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -14,10 +14,10 @@ case class SearchFilters(
     bbox: Option[Bbox] = None,
     datetime: Option[TemporalExtent] = None,
     intersects: Option[Geometry] = None,
-    collections: List[String] = Nil,
-    items: List[String] = Nil,
+    collections: Option[List[String]] = None,
+    items: Option[List[String]] = None,
     limit: Option[NonNegInt] = None,
-    query: Map[String, List[Query]] = Map.empty,
+    query: Option[Map[String, List[Query]]] = None,
     next: Option[PaginationToken] = None
 )
 
@@ -39,10 +39,10 @@ object SearchFilters extends ClientCodecs {
         bbox,
         datetime,
         intersects,
-        collectionsOption.getOrElse(Nil),
-        itemsOption.getOrElse(Nil),
+        collectionsOption,
+        itemsOption,
         limit,
-        query getOrElse Map.empty,
+        query,
         paginationToken
       )
     }

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -3,6 +3,7 @@ package com.azavea.stac4s.api.client
 import com.azavea.stac4s.api.client.util.ClientCodecs
 import com.azavea.stac4s.{Bbox, TemporalExtent}
 
+import cats.syntax.option._
 import eu.timepit.refined.types.numeric.NonNegInt
 import geotrellis.vector.{io => _, _}
 import io.circe._
@@ -14,10 +15,10 @@ case class SearchFilters(
     bbox: Option[Bbox] = None,
     datetime: Option[TemporalExtent] = None,
     intersects: Option[Geometry] = None,
-    collections: Option[List[String]] = None,
-    items: Option[List[String]] = None,
+    collections: List[String] = Nil,
+    items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
-    query: Option[Map[String, List[Query]]] = None,
+    query: Map[String, List[Query]] = Map.empty,
     next: Option[PaginationToken] = None
 )
 
@@ -39,10 +40,10 @@ object SearchFilters extends ClientCodecs {
         bbox,
         datetime,
         intersects,
-        collectionsOption,
-        itemsOption,
+        collectionsOption getOrElse Nil,
+        itemsOption getOrElse Nil,
         limit,
-        query,
+        query getOrElse Map.empty,
         paginationToken
       )
     }
@@ -62,10 +63,10 @@ object SearchFilters extends ClientCodecs {
       filters.bbox,
       filters.datetime,
       filters.intersects,
-      filters.collections,
-      filters.items,
+      filters.collections.some.filter(_.nonEmpty),
+      filters.items.some.filter(_.nonEmpty),
       filters.limit,
-      filters.query,
+      filters.query.some.filter(_.nonEmpty),
       filters.next
     )
   )

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
@@ -84,7 +84,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
         basicRequest
           .post(baseUri.addPath("collections"))
           .contentType(MediaType.ApplicationJson)
-          .body(collection.asJson.deepDropNullValues.noSpaces)
+          .body(collection.asJson.noSpaces)
           .response(asJson[StacCollection])
       )
       .flatMap(_.body.liftTo[F])
@@ -117,7 +117,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
         basicRequest
           .post(baseUri.addPath("collections", collectionId.value, "items"))
           .contentType(MediaType.ApplicationJson)
-          .body(item.asJson.deepDropNullValues.noSpaces)
+          .body(item.asJson.noSpaces)
           .response(asJson[StacItem])
       )
       .flatMap(_.bodyETag.liftTo[F])

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
@@ -44,7 +44,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
             basicRequest
               .post(link)
               .contentType(MediaType.ApplicationJson)
-              .body(request.noSpaces)
+              .body(request.deepDropNullValues.noSpaces)
               .response(asJson[Json])
           )
           .flatMap { response =>
@@ -84,7 +84,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
         basicRequest
           .post(baseUri.addPath("collections"))
           .contentType(MediaType.ApplicationJson)
-          .body(collection.asJson.noSpaces)
+          .body(collection.asJson.deepDropNullValues.noSpaces)
           .response(asJson[StacCollection])
       )
       .flatMap(_.body.liftTo[F])
@@ -117,7 +117,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
         basicRequest
           .post(baseUri.addPath("collections", collectionId.value, "items"))
           .contentType(MediaType.ApplicationJson)
-          .body(item.asJson.noSpaces)
+          .body(item.asJson.deepDropNullValues.noSpaces)
           .response(asJson[StacItem])
       )
       .flatMap(_.bodyETag.liftTo[F])


### PR DESCRIPTION
## Overview

This PR sets content type to all client post requests as well as adjusts SearchFilters (make all fields optional + drop nulls in requests) case class to make client more compatible with different STAC API Implementations.

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
