### PR TITLE
Ensure json errors accumulate for custom decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Fixed
+- Corrected error accumulation for custom decoders [#373](https://github.com/azavea/stac4s/pull/373)
 
 ## [0.6.1] - 2021-07-13
 ### Changed

--- a/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
+++ b/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
@@ -127,7 +127,10 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
   }
 
   test("Assets accumulate errors") {
-    accumulatingDecodeTest[StacAsset]
+    // StacAssets actually only have one required field, so an empty json object only
+    // decodes with one error even with accumulation
+    decodeAccumulating[StacAsset]("""{"href": 1234, "title": 1234}""")
+      .fold(errs => errs.size shouldBe 2, _ => fail("Decoding should not have succeeded"))
   }
 
   test("Extents accumulate errors") {

--- a/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
+++ b/modules/core-test/shared/src/test/scala/com/azavea/stac4s/SerDeSpec.scala
@@ -7,6 +7,7 @@ import com.azavea.stac4s.extensions.layer._
 import com.azavea.stac4s.meta.ForeignImplicits._
 import com.azavea.stac4s.testing.TestInstances._
 
+import io.circe.Decoder
 import io.circe.parser._
 import io.circe.syntax._
 import io.circe.testing.{ArbitraryInstances, CodecTests}
@@ -68,6 +69,15 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
   private def getTimeDecodeTest(timestring: String): Assertion =
     timestring.asJson.as[Instant] shouldBe Right(OffsetDateTime.parse(timestring, RFC3339formatter).toInstant)
 
+  private def accumulatingDecodeTest[T: Decoder]: Assertion =
+    decodeAccumulating[T]("{}").fold(
+      errs => {
+        println(s"Errs: $errs")
+        errs.size should be > 1
+      },
+      _ => fail("Decoding succeeded but should not have")
+    )
+
   test("Instant decodes timestrings with +0x:00 timezones") {
     getTimeDecodeTest("2018-01-01T00:00:00+05:00")
   }
@@ -98,5 +108,29 @@ class SerDeSpec extends AnyFunSuite with FunSuiteDiscipline with Checkers with M
 
   test("Instant decodes timestring with 1e9 Z format timezone") {
     getTimeDecodeTest("2018-04-03T11:32:26.553955473Z")
+  }
+
+  test("Collections accumulate errors") {
+    accumulatingDecodeTest[StacCollection]
+  }
+
+  test("Items accumulate errors") {
+    accumulatingDecodeTest[StacItem]
+  }
+
+  test("Catalogs accumulate errors") {
+    accumulatingDecodeTest[StacCatalog]
+  }
+
+  test("Links accumulate errors") {
+    accumulatingDecodeTest[StacLink]
+  }
+
+  test("Assets accumulate errors") {
+    accumulatingDecodeTest[StacAsset]
+  }
+
+  test("Extents accumulate errors") {
+    accumulatingDecodeTest[StacExtent]
   }
 }

--- a/modules/core/shared/src/main/scala/com/azavea/stac4s/StacLink.scala
+++ b/modules/core/shared/src/main/scala/com/azavea/stac4s/StacLink.scala
@@ -1,6 +1,7 @@
 package com.azavea.stac4s
 
 import cats.syntax.apply._
+import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
 
@@ -27,30 +28,35 @@ object StacLink {
     baseEncoder(link).deepMerge(link.extensionFields.asJson).dropNullValues
   }
 
-  implicit val decStacLink: Decoder[StacLink] = { c: HCursor =>
-    (
-      c.downField("href").as[String],
-      c.downField("rel").as[StacLinkType],
-      c.get[Option[StacMediaType]]("type"),
-      c.get[Option[String]]("title"),
-      c.value.as[JsonObject]
-    ).mapN(
+  implicit val decStacLink: Decoder[StacLink] = new Decoder[StacLink] {
+
+    override def decodeAccumulating(c: HCursor) = {
       (
-          href: String,
-          rel: StacLinkType,
-          _type: Option[StacMediaType],
-          title: Option[String],
-          document: JsonObject
-      ) =>
-        StacLink(
-          href,
-          rel,
-          _type,
-          title,
-          document.filter({ case (k, _) =>
-            !linkFields.contains(k)
-          })
-        )
-    )
+        c.downField("href").as[String].toValidatedNel,
+        c.downField("rel").as[StacLinkType].toValidatedNel,
+        c.get[Option[StacMediaType]]("type").toValidatedNel,
+        c.get[Option[String]]("title").toValidatedNel,
+        c.value.as[JsonObject].toValidatedNel
+      ).mapN(
+        (
+            href: String,
+            rel: StacLinkType,
+            _type: Option[StacMediaType],
+            title: Option[String],
+            document: JsonObject
+        ) =>
+          StacLink(
+            href,
+            rel,
+            _type,
+            title,
+            document.filter({ case (k, _) =>
+              !linkFields.contains(k)
+            })
+          )
+      )
+    }
+
+    def apply(c: HCursor) = decodeAccumulating(c).toEither.leftMap(_.head)
   }
 }


### PR DESCRIPTION
## Overview

This PR defines `apply` in terms of `decodeAccumulating` to ensure the behavior of `decodeAccumulating` is correct. Previously `decodeAccumulating` relied on the default implementation for a codec with an `apply` defined, which takes the `Result` (an `Either`) and wraps the error in a `ValidatedNel` if present: https://github.com/circe/circe/blob/master/modules/core/shared/src/main/scala/io/circe/Decoder.scala#L50-L60. Here instead we flip it.

We didn't accumulate errors previously despite using `mapN` because `c.get` returns an `Either`, and `Either`'s applicative doesn't accumulate 🕵🏻‍♂️

### Checklist

- [x] New tests have been added or existing tests have been modified
- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

Closes #372 
