### PR TITLE
Bump JTS version up to 1.17.0 in the Scala 2.13 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,7 +103,7 @@ lazy val credentialSettings = Seq(
 
 val jvmGeometryDependencies = Def.setting {
   Seq(
-    "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
+    "org.locationtech.jts"         % "jts-core"          % Versions.Jts.value,
     "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis.value
   )
 }
@@ -118,7 +118,7 @@ val coreDependenciesJVM = Def.setting {
 val testingDependenciesJVM = Def.setting {
   Seq(
     "org.locationtech.geotrellis" %% "geotrellis-vector" % Versions.GeoTrellis.value,
-    "org.locationtech.jts"         % "jts-core"          % Versions.Jts,
+    "org.locationtech.jts"         % "jts-core"          % Versions.Jts.value,
     "org.threeten"                 % "threeten-extra"    % Versions.ThreeTenExtra
   )
 }

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -17,7 +17,7 @@ object Versions {
   val DisciplineScalatest     = "2.1.5"
   val Enumeratum              = "1.7.0"
   val GeoTrellis              = Def.setting(ver("3.6.0", "3.6.1-SNAPSHOT").value)
-  val Jts                     = "1.16.1"
+  val Jts                     = Def.setting(ver("1.16.1", "1.17.0").value)
   val Monocle                 = "2.1.0"
   val Refined                 = "0.9.27"
   val ScalacheckCats          = "0.3.1"


### PR DESCRIPTION
## Overview

This PR resolves the current CI run issues.