### PR TITLE
Expose client.search overload with an optional filter argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+### Chnaged
+- Expose client.search overload with an optional filter argument [#406](https://github.com/azavea/stac4s/pull/406)
 
 ## [0.7.0] - 2021-09-21
 ### Fixed

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/StacClientF.scala
@@ -19,5 +19,6 @@ trait StreamingStacClientF[F[_], G[_], S] extends StacClientF[F, S] {
   def collections: G[StacCollection]
   def search: G[StacItem]
   def search(filter: S): G[StacItem]
+  def search(filter: Option[S]): G[StacItem]
   def items(collectionId: NonEmptyString): G[StacItem]
 }

--- a/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
+++ b/modules/client/shared/src/main/scala/com/azavea/stac4s/api/client/SttpStacClientF.scala
@@ -31,7 +31,7 @@ case class SttpStacClientF[F[_]: MonadThrow, S: Lens[*, Option[PaginationToken]]
 
   def search(filter: S): Stream[F, StacItem] = search(filter.some)
 
-  private def search(filter: Option[S]): Stream[F, StacItem] = {
+  def search(filter: Option[S]): Stream[F, StacItem] = {
     val emptyJson = JsonObject.empty.asJson
     // the initial filter may contain the paginationToken that is used for the initial query
     val initialBody = filter.map(_.asJson).getOrElse(emptyJson)


### PR DESCRIPTION
## Overview

This PR adds a convenient extra overload.

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))
