### PR TITLE
Make SearchFilters pagination agnostic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ workflows:
       - openjdk8-build:
           matrix:
             parameters:
-              scala-version: ["2.12.15", "2.13.7"]
+              scala-version: ["2.12.15", "2.13.8"]
           # required since openjdk8-deploy has tag filters AND requires
           # openjdk8
           # https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
@@ -89,7 +89,7 @@ workflows:
       - openjdk8-deploy:
           matrix:
             parameters:
-              scala-version: ["2.13.7"]
+              scala-version: ["2.13.8"]
           context: sonatype-azavea-signing-key
           requires:
             - openjdk8-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 ### Changed
 - Pagination Improvements [#496](https://github.com/azavea/stac4s/pull/496)
+- Make SearchFilters pagination agnostic [#502](https://github.com/azavea/stac4s/pull/502) 
 
 ## [0.7.2] - 2021-10-12
 ### Changed

--- a/build.sbt
+++ b/build.sbt
@@ -220,8 +220,6 @@ lazy val client = crossProject(JSPlatform, JVMPlatform)
   .settings(publishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "com.github.julien-truffaut"    %%% "monocle-core"  % Versions.Monocle,
-      "com.github.julien-truffaut"    %%% "monocle-macro" % Versions.Monocle,
       "io.circe"                      %%% "circe-core"    % Versions.Circe,
       "io.circe"                      %%% "circe-generic" % Versions.Circe,
       "io.circe"                      %%% "circe-refined" % Versions.Circe,

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -1,16 +1,14 @@
 package com.azavea.stac4s.api.client
 
-import com.azavea.stac4s.api.client.SttpStacClientF.PaginationToken
 import com.azavea.stac4s.api.client.util.ClientCodecs
 import com.azavea.stac4s.geometry.Geometry
-import com.azavea.stac4s.{Bbox, TemporalExtent}
+import com.azavea.stac4s.{Bbox, TemporalExtent, productFieldNames}
 
 import cats.syntax.option._
 import eu.timepit.refined.types.numeric.NonNegInt
 import io.circe._
 import io.circe.refined._
-import monocle.Lens
-import monocle.macros.GenLens
+import io.circe.syntax._
 
 case class SearchFilters(
     bbox: Option[Bbox] = None,
@@ -20,11 +18,11 @@ case class SearchFilters(
     items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
     query: Map[String, List[Query]] = Map.empty,
-    next: Option[PaginationToken] = None
+    paginationBody: JsonObject = JsonObject.empty
 )
 
 object SearchFilters extends ClientCodecs {
-  implicit val paginationTokenLens: Lens[SearchFilters, Option[PaginationToken]] = GenLens[SearchFilters](_.next)
+  val searchFilterFields = productFieldNames[SearchFilters]
 
   implicit val searchFiltersDecoder: Decoder[SearchFilters] = { c =>
     for {
@@ -35,7 +33,7 @@ object SearchFilters extends ClientCodecs {
       itemsOption       <- c.downField("ids").as[Option[List[String]]]
       limit             <- c.downField("limit").as[Option[NonNegInt]]
       query             <- c.get[Option[Map[String, List[Query]]]]("query")
-      paginationToken   <- c.get[Option[PaginationToken]]("next")
+      document          <- c.value.as[JsonObject]
     } yield {
       SearchFilters(
         bbox,
@@ -45,30 +43,32 @@ object SearchFilters extends ClientCodecs {
         itemsOption getOrElse Nil,
         limit,
         query getOrElse Map.empty,
-        paginationToken
+        document.filter { case (k, _) => !searchFilterFields.contains(k) }
       )
     }
   }
 
-  implicit val searchFiltersEncoder: Encoder[SearchFilters] = Encoder.forProduct8(
-    "bbox",
-    "datetime",
-    "intersects",
-    "collections",
-    "ids",
-    "limit",
-    "query",
-    "next"
-  )(filters =>
-    (
-      filters.bbox,
-      filters.datetime,
-      filters.intersects,
-      filters.collections.some.filter(_.nonEmpty),
-      filters.items.some.filter(_.nonEmpty),
-      filters.limit,
-      filters.query.some.filter(_.nonEmpty),
-      filters.next
-    )
-  )
+  implicit val searchFiltersEncoder: Encoder[SearchFilters] = { filters =>
+    val fieldsEncoder = Encoder.forProduct7(
+      "bbox",
+      "datetime",
+      "intersects",
+      "collections",
+      "ids",
+      "limit",
+      "query"
+    ) { filters: SearchFilters =>
+      (
+        filters.bbox,
+        filters.datetime,
+        filters.intersects,
+        filters.collections.some.filter(_.nonEmpty),
+        filters.items.some.filter(_.nonEmpty),
+        filters.limit,
+        filters.query.some.filter(_.nonEmpty)
+      )
+    }
+
+    fieldsEncoder(filters).deepMerge(filters.paginationBody.asJson)
+  }
 }

--- a/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/js/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -18,6 +18,8 @@ case class SearchFilters(
     items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
     query: Map[String, List[Query]] = Map.empty,
+    // according to the STAC Spec, any fields can be used to represent pagination
+    // for more details see https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/item-search#pagination
     paginationBody: JsonObject = JsonObject.empty
 )
 
@@ -26,12 +28,12 @@ object SearchFilters extends ClientCodecs {
 
   implicit val searchFiltersDecoder: Decoder[SearchFilters] = { c =>
     for {
-      bbox              <- c.downField("bbox").as[Option[Bbox]]
-      datetime          <- c.downField("datetime").as[Option[TemporalExtent]]
-      intersects        <- c.downField("intersects").as[Option[Geometry]]
-      collectionsOption <- c.downField("collections").as[Option[List[String]]]
-      itemsOption       <- c.downField("ids").as[Option[List[String]]]
-      limit             <- c.downField("limit").as[Option[NonNegInt]]
+      bbox              <- c.get[Option[Bbox]]("bbox")
+      datetime          <- c.get[Option[TemporalExtent]]("datetime")
+      intersects        <- c.get[Option[Geometry]]("intersects")
+      collectionsOption <- c.get[Option[List[String]]]("collections")
+      itemsOption       <- c.get[Option[List[String]]]("ids")
+      limit             <- c.get[Option[NonNegInt]]("limit")
       query             <- c.get[Option[Map[String, List[Query]]]]("query")
       document          <- c.value.as[JsonObject]
     } yield {

--- a/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
+++ b/modules/client/jvm/src/main/scala/com/azavea/stac4s/api/client/SearchFilters.scala
@@ -18,6 +18,8 @@ case class SearchFilters(
     items: List[String] = Nil,
     limit: Option[NonNegInt] = None,
     query: Map[String, List[Query]] = Map.empty,
+    // according to the STAC Spec, any fields can be used to represent pagination
+    // for more details see https://github.com/radiantearth/stac-api-spec/tree/v1.0.0-rc.1/item-search#pagination
     paginationBody: JsonObject = JsonObject.empty
 )
 
@@ -26,12 +28,12 @@ object SearchFilters extends ClientCodecs {
 
   implicit val searchFiltersDecoder: Decoder[SearchFilters] = { c =>
     for {
-      bbox              <- c.downField("bbox").as[Option[Bbox]]
-      datetime          <- c.downField("datetime").as[Option[TemporalExtent]]
-      intersects        <- c.downField("intersects").as[Option[Geometry]]
-      collectionsOption <- c.downField("collections").as[Option[List[String]]]
-      itemsOption       <- c.downField("ids").as[Option[List[String]]]
-      limit             <- c.downField("limit").as[Option[NonNegInt]]
+      bbox              <- c.get[Option[Bbox]]("bbox")
+      datetime          <- c.get[Option[TemporalExtent]]("datetime")
+      intersects        <- c.get[Option[Geometry]]("intersects")
+      collectionsOption <- c.get[Option[List[String]]]("collections")
+      itemsOption       <- c.get[Option[List[String]]]("ids")
+      limit             <- c.get[Option[NonNegInt]]("limit")
       query             <- c.get[Option[Map[String, List[Query]]]]("query")
       document          <- c.value.as[JsonObject]
     } yield {


### PR DESCRIPTION
## Overview

This PR makes SearchFilters case class pagination agnostic. It complements https://github.com/azavea/stac4s/pull/496.

### Checklist

- [x] Changelog updated (please use [`chan`](https://www.npmjs.com/package/@geut/chan))

