### PR TITLE
Fix circle deploy for 2.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,8 +121,8 @@ workflows:
             - openjdk-build-executor-openjdk11-2.13.8
           filters:
             tags:
-              ignore:
-                - /^(.*)$/
+              only:
+                - /^(v.*)$/
             branches:
               only:
                 - master


### PR DESCRIPTION
## Overview

This PR updates deployments to run for scala 2.13
